### PR TITLE
eval: fix phase underflow

### DIFF
--- a/src/eval.zig
+++ b/src/eval.zig
@@ -473,7 +473,7 @@ pub fn evaluate(board: *const Board, eval_state: EvalState) i16 {
     side_independent += @intCast(mobility * mobility_mult >> 16);
 
     // passed pawns are only really useful in the endgame, so essentially add them to the eg score
-    side_independent += @intCast(@divTrunc((passedPawnScore(board) * passed_pawn_mult >> 16) * (total_phase - eval_state.phase), total_phase));
+    side_independent += @intCast(@divTrunc((passedPawnScore(board) * passed_pawn_mult >> 16) * (total_phase -| eval_state.phase), total_phase));
     // side_independent += tempo;
     return psqt_eval + if (board.turn == .white) side_independent else -side_independent;
 }


### PR DESCRIPTION
Fix phase underflow, `phase` can exceed `total_phase`.

Relevant stack trace:
```
$ zig build run -- bench
thread 1609176 panic: integer overflow
/home/lily/repos/pawnocchio/src/eval.zig:476:109: 0x1132bd3 in evaluate (pawnocchio)
    side_independent += @intCast(@divTrunc((passedPawnScore(board) * passed_pawn_mult >> 16) * (total_phase - eval_state.phase), total_phase));
                                                                                                            ^
/home/lily/repos/pawnocchio/src/search.zig:39:33: 0x1116aa6 in quiesce__anon_10139 (pawnocchio)
    const static_eval = evaluate(board, eval_state);
                                ^
/home/lily/repos/pawnocchio/src/search.zig:56:31: 0x111220c in quiesce__anon_10118 (pawnocchio)
        const score = -quiesce(
                              ^
/home/lily/repos/pawnocchio/src/search.zig:56:31: 0x1116fac in quiesce__anon_10139 (pawnocchio)
        const score = -quiesce(
                              ^
/home/lily/repos/pawnocchio/src/search.zig:134:30: 0x11146da in search__anon_10136 (pawnocchio)
        const score = quiesce(
                             ^
/home/lily/repos/pawnocchio/src/search.zig:162:29: 0x1119386 in search__anon_10141 (pawnocchio)
            score = -(search(
                            ^
/home/lily/repos/pawnocchio/src/search.zig:162:29: 0x1114d16 in search__anon_10136 (pawnocchio)
            score = -(search(
                            ^
/home/lily/repos/pawnocchio/src/search.zig:162:29: 0x1119386 in search__anon_10141 (pawnocchio)
            score = -(search(
                            ^
/home/lily/repos/pawnocchio/src/search.zig:162:29: 0x1114d16 in search__anon_10136 (pawnocchio)
            score = -(search(
                            ^
/home/lily/repos/pawnocchio/src/search.zig:162:29: 0x1119386 in search__anon_10141 (pawnocchio)
            score = -(search(
                            ^
/home/lily/repos/pawnocchio/src/search.zig:162:29: 0x10f73c0 in search__anon_8889 (pawnocchio)
            score = -(search(
                            ^
/home/lily/repos/pawnocchio/src/search.zig:264:41: 0x10b8264 in iterativeDeepening (pawnocchio)
            inline else => |turn| search(
                                        ^
/home/lily/repos/pawnocchio/src/engine.zig:120:37: 0x10a9ede in searchSync (pawnocchio)
    return search.iterativeDeepening(board, search_parameters, move_buf, hash_history, silence_output);
                                    ^
/home/lily/repos/pawnocchio/src/main.zig:120:47: 0x10a5d3a in main (pawnocchio)
                const info = engine.searchSync(board, .{ .depth = depth }, move_buf, &hash_history, true);
                                              ^
/usr/lib/zig/std/start.zig:524:37: 0x109ce25 in posixCallMainAndExit (pawnocchio)
            const result = root.main() catch |err| {
                                    ^
/usr/lib/zig/std/start.zig:266:5: 0x109c941 in _start (pawnocchio)
    asm volatile (switch (native_arch) {
    ^
???:?:?: 0x1 in ??? (???)
Unwind information for `???:0x1` was not available, trace may be incomplete
```