### PR TITLE
Set self.fullmove when parsing FENs

### DIFF
--- a/src/Board.zig
+++ b/src/Board.zig
@@ -389,6 +389,7 @@ pub fn parseFen(ifen: []const u8, permissive: bool) !Board {
     const fullmove = try std.fmt.parseInt(u32, fullmove_clock_str, 10);
     if (!permissive and fullmove == 0)
         return error.InvalidFullMove;
+    self.fullmove = fullmove;
     self.plies = fullmove * 2 + self.stm.toInt();
     self.resetHash();
     self.updateMasks(self.stm);


### PR DESCRIPTION
Fixes the following issue with round-tripping:

```
$ ./zig-out/bin/pawnocchio
position fen r1b1kbnr/pp1ppppp/1qn5/8/3p4/4P2P/PPPKNPP1/RNBQ1B1R b kq - 1 5
d
zobrist: 1474662212642456544
r1b1kbnr/pp1ppppp/1qn5/8/3p4/4P2P/PPPKNPP1/RNBQ1B1R b kq - 1 1
```