### PR TITLE
2048hl pairwise net, +2 elo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,5 @@ NET_SPECIFIER=
 endif
 
 default: net
-	zig build --release=fast install $(NET_SPECIFIER) -Druntime_net
+	zig build --release=fast install $(NET_SPECIFIER)
 	@$(MV)

--- a/build.zig
+++ b/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
     const name = b.option([]const u8, "name", "Change the name of the binary") orelse "pawnocchio";
 
-    const net_name = "mixed_data_dualact.nnue";
+    const net_name = "mixed_data_dualact_higher_wdl.nnue";
 
     const net = b.option([]const u8, "net", "Change the net to be used") orelse blk: {
         break :blk "pawnocchio-nets/networks/" ++ net_name;

--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) !void {
     const name = b.option([]const u8, "name", "Change the name of the binary") orelse "pawnocchio";
     const runtime_net = b.option(bool, "runtime_net", "whether to exclude the binary from the binary") orelse false;
 
-    const net_name = "mixed_data_01_03.nnue";
+    const net_name = "mixed_data_2048pw.nnue";
     const net = b.option([]const u8, "net", "Change the net to be used") orelse blk: {
         break :blk "pawnocchio-nets/networks/" ++ net_name;
     };

--- a/build.zig
+++ b/build.zig
@@ -1,15 +1,37 @@
 const std = @import("std");
+const builtin = @import("builtin");
+
+const nnue_arch = @import("src/nnue_arch.zig");
+const Weights = nnue_arch.Weights;
+
+fn readNet(path: []const u8, allocator: std.mem.Allocator) !*Weights {
+    var file = try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+
+    const from_file: *Weights = try allocator.create(Weights);
+    _ = try file.readAll(std.mem.asBytes(from_file));
+
+    return from_file;
+}
 
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const name = b.option([]const u8, "name", "Change the name of the binary") orelse "pawnocchio";
-    const runtime_net = b.option(bool, "runtime_net", "whether to exclude the binary from the binary") orelse false;
 
-    const net_name = "mixed_data_2048pw.nnue";
+    const net_name = "mixed_data_2048pw_ml_int.nnue";
+
     const net = b.option([]const u8, "net", "Change the net to be used") orelse blk: {
         break :blk "pawnocchio-nets/networks/" ++ net_name;
     };
+
+    const net_weights = try readNet(net, b.allocator);
+    defer b.allocator.destroy(net_weights);
+    nnue_arch.permuteNet(target.result.cpu, net_weights);
+    const permuted_net_writing_step = b.addWriteFiles();
+    const permuted_net_path = permuted_net_writing_step.add("net", std.mem.asBytes(net_weights));
+
+    const net_module = b.createModule(.{ .root_source_file = permuted_net_path });
 
     const dynamic = b.option(bool, "dynamic", "build a dynamic executable") orelse false;
     const static = b.option(bool, "static", "build a static executable") orelse false;
@@ -24,19 +46,13 @@ pub fn build(b: *std.Build) !void {
     if (static) {
         linkage_mode = .static;
     }
-    const emit_symbols = b.option(bool, "emit_symbols", "force debug symbols not to be strippped") orelse false;
+    const emit_symbols = b.option(bool, "emit_symbols", "force debug symbols not to be stripped") orelse false;
     const use_tbs = b.option(bool, "use_tbs", "whether to enable tablebases") orelse true;
     const minimal_executable = switch (optimize) {
         .ReleaseFast, .ReleaseSmall => true,
         .Debug, .ReleaseSafe => false,
     } and !emit_symbols;
-    const net_module = b.createModule(
-        .{
-            .root_source_file = std.Build.LazyPath{
-                .cwd_relative = net, // OB passes the path as an absolute path so this is is the only way
-            },
-        },
-    );
+
     var net_abs_buf: [4096]u8 = undefined;
     const net_absolute = try std.fs.cwd().realpath(net, &net_abs_buf);
 
@@ -50,12 +66,14 @@ pub fn build(b: *std.Build) !void {
             .strip = minimal_executable,
             .link_libc = target.result.os.tag == .windows or use_tbs,
         }),
+        .use_llvm = true,
         .linkage = linkage_mode,
     });
+    exe.root_module.addImport("net", net_module);
+    exe.step.dependOn(&permuted_net_writing_step.step);
 
     const exe_options = b.addOptions();
     exe_options.addOption(bool, "use_tbs", use_tbs);
-    exe_options.addOption(bool, "runtime_net", runtime_net);
     exe_options.addOption([]const u8, "net_name", net_name);
     exe_options.addOption([]const u8, "net_path", net_absolute);
     exe.root_module.addOptions("build_options", exe_options);
@@ -70,7 +88,6 @@ pub fn build(b: *std.Build) !void {
         });
         exe.addIncludePath(b.path("src/Pyrrhic/"));
     }
-    exe.root_module.addImport("net", net_module);
     b.installArtifact(exe);
 
     const run_cmd = b.addRunArtifact(exe);
@@ -84,7 +101,6 @@ pub fn build(b: *std.Build) !void {
     run_step.dependOn(&run_cmd.step);
     const test_options = b.addOptions();
     test_options.addOption(bool, "use_tbs", false);
-    test_options.addOption(bool, "runtime_net", runtime_net);
     test_options.addOption([]const u8, "net_path", net);
 
     const exe_unit_tests = b.addTest(.{
@@ -96,6 +112,7 @@ pub fn build(b: *std.Build) !void {
     });
     exe_unit_tests.root_module.addImport("net", net_module);
     exe_unit_tests.root_module.addOptions("build_options", test_options);
+    exe_unit_tests.step.dependOn(&permuted_net_writing_step.step);
     const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
 
     const lib_unit_tests = b.addTest(.{
@@ -107,6 +124,8 @@ pub fn build(b: *std.Build) !void {
     });
     lib_unit_tests.root_module.addImport("net", net_module);
     lib_unit_tests.root_module.addOptions("build_options", test_options);
+    lib_unit_tests.step.dependOn(&permuted_net_writing_step.step);
+
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
 
     const test_step = b.step("test", "run unit tests");

--- a/build.zig
+++ b/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
     const name = b.option([]const u8, "name", "Change the name of the binary") orelse "pawnocchio";
 
-    const net_name = "mixed_data_2048pw_ml_int.nnue";
+    const net_name = "mixed_data_dualact.nnue";
 
     const net = b.option([]const u8, "net", "Change the net to be used") orelse blk: {
         break :blk "pawnocchio-nets/networks/" ++ net_name;

--- a/src/Limits.zig
+++ b/src/Limits.zig
@@ -85,16 +85,17 @@ pub fn checkSearch(self: *Limits, nodes: u64) bool {
 }
 
 fn computeNodeCountFactor(_: *const Limits, best_move_count: u64, total_nodes: u64) u128 {
-    const node_fraction = @as(u128, best_move_count) * 1024 / @max(1, total_nodes);
-    return @as(u64, @intCast(tunable_constants.nodetm_mult)) * (@as(u64, @intCast(tunable_constants.nodetm_base)) - node_fraction);
+    const best_count = @min(best_move_count, total_nodes);
+    const node_fraction = @as(u128, best_count) * 1024 / @max(1, total_nodes);
+    return @as(u64, @intCast(tunable_constants.nodetm_mult)) * (@as(u64, @intCast(tunable_constants.nodetm_base)) -| node_fraction);
 }
 
 fn computeEvalStabilityFactor(_: *const Limits, stab: i64) u64 {
-    return @intCast(@max(tunable_constants.eval_stab_lim, tunable_constants.eval_stab_base - @divTrunc(tunable_constants.eval_stab_offs * stab, 1024)));
+    return @intCast(@max(tunable_constants.eval_stab_lim, tunable_constants.eval_stab_base -| @divTrunc(tunable_constants.eval_stab_offs * stab, 1024)));
 }
 
 fn computeMoveStabilityFactor(_: *const Limits, stab: i64) u64 {
-    return @intCast(@max(tunable_constants.move_stab_lim, tunable_constants.move_stab_base - @divTrunc(tunable_constants.move_stab_offs * stab, 1024)));
+    return @intCast(@max(tunable_constants.move_stab_lim, tunable_constants.move_stab_base -| @divTrunc(tunable_constants.move_stab_offs * stab, 1024)));
 }
 
 pub fn checkRoot(
@@ -150,7 +151,7 @@ pub fn checkRootTime(
 
 pub fn shouldPrintInfoInAspiration(self: *Limits) bool {
     const cur_time = self.timer.read();
-    if (cur_time - self.last_aspiration_print > std.time.ns_per_s) {
+    if (cur_time -| self.last_aspiration_print > std.time.ns_per_s) {
         self.last_aspiration_print = cur_time;
         return true;
     }

--- a/src/MovePicker.zig
+++ b/src/MovePicker.zig
@@ -148,14 +148,8 @@ inline fn findBest(noalias self: *MovePicker) usize {
 fn noisyValue(self: MovePicker, move: Move) i32 {
     var res: i32 = 0;
 
-    // if (self.board.isPromo(move)) {
-    //     res += SEE.value(move.promoType());
-    // }
-    if (self.board.pieceOn(move.to())) |captured_type| {
-        res += SEE.value(captured_type, .ordering);
-    } else if (self.board.isEnPassant(move)) {
-        res += SEE.value(.pawn, .ordering);
-    }
+    res += @intFromBool(move.tp() == .ep) * SEE.value(.pawn, .ordering);
+    res += SEE.value(self.board.pieceOn(move.to()) orelse .king, .ordering);
     res = @divFloor(res * root.tunable_constants.mvv_mult, 32);
     res += self.histories.readNoisy(self.board, move);
 

--- a/src/nnue.zig
+++ b/src/nnue.zig
@@ -46,7 +46,7 @@ pub const INPUT_BUCKET_LAYOUT = arch.INPUT_BUCKET_LAYOUT;
 
 pub const VEC_BYTES = arch.vecBytes(@import("builtin").cpu);
 
-fn vecSize(comptime T: type) comptime_int {
+pub fn vecSize(comptime T: type) comptime_int {
     return VEC_BYTES / @sizeOf(T);
 }
 
@@ -538,11 +538,15 @@ const Accumulator = struct {
         {
             const w: [*]const i8 = &(&weights.l1w)[output_bucket];
             const ft_i32: [*]i32 = @ptrCast(&activated_ft);
+
+            const nonzero_indices, const num_nonzero_indices = @import("sparse.zig").findNonZeroIndices(&activated_ft);
+
             var i_outer: usize = 0;
-            while (i_outer + L2_UNROLL <= L1_SIZE / 4) : (i_outer += L2_UNROLL) {
+
+            while (i_outer + L2_UNROLL <= num_nonzero_indices) : (i_outer += L2_UNROLL) {
                 for (0..L2_SIZE / vecSize(i32)) |j| {
                     for (0..L2_UNROLL) |i_inner| {
-                        const i = i_outer + i_inner;
+                        const i = nonzero_indices[i_outer + i_inner];
                         const ft_vec: u8Vec = @bitCast(@as(i32Vec, @splat(ft_i32[i])));
                         l1_intermediate[j][i_inner] = c.dpbusd(
                             l1_intermediate[j][i_inner],
@@ -552,11 +556,11 @@ const Accumulator = struct {
                     }
                 }
             }
-            while (i_outer < L1_SIZE / 4) : (i_outer += 1) {
-                const ft_vec: u8Vec = @bitCast(@as(i32Vec, @splat(ft_i32[i_outer])));
+            while (i_outer < num_nonzero_indices) : (i_outer += 1) {
+                const i = nonzero_indices[i_outer];
+                const ft_vec: u8Vec = @bitCast(@as(i32Vec, @splat(ft_i32[i])));
 
                 for (0..L2_SIZE / vecSize(i32)) |j| {
-                    const i = i_outer;
                     l1_intermediate[j][0] = c.dpbusd(
                         l1_intermediate[j][0],
                         ft_vec,

--- a/src/nnue.zig
+++ b/src/nnue.zig
@@ -52,7 +52,7 @@ fn mullo(
 const Weights = extern struct {
     hidden_layer_weights: [HIDDEN_SIZE * INPUT_SIZE * INPUT_BUCKET_COUNT]i16 align(std.atomic.cache_line),
     hidden_layer_biases: [HIDDEN_SIZE]i16 align(std.atomic.cache_line),
-    output_weights: [HIDDEN_SIZE * 2 * OUTPUT_BUCKET_COUNT]i16 align(std.atomic.cache_line),
+    output_weights: [HIDDEN_SIZE * OUTPUT_BUCKET_COUNT]i16 align(std.atomic.cache_line),
     output_biases: [OUTPUT_BUCKET_COUNT]i16 align(std.atomic.cache_line),
     const WEIGHT_COUNT = blk: {
         var res = 0;
@@ -336,21 +336,26 @@ const Accumulator = struct {
         const ONE: Vec = @splat(QA);
         var i: usize = 0;
         const which_bucket = whichOutputBucket(board);
-        const bucket_offset = which_bucket * HIDDEN_SIZE * 2;
-        while (i < HIDDEN_SIZE) {
+        const bucket_offset = which_bucket * HIDDEN_SIZE;
+        while (i < HIDDEN_SIZE / 2) {
             inline for (&accs) |*acc| {
                 defer i += VEC_SIZE;
-                const us: Vec = us_acc[i..][0..VEC_SIZE].*;
-                const us_clamped: Vec = @max(@min(us, ONE), ZERO);
-                const them: Vec = them_acc[i..][0..VEC_SIZE].*;
-                const them_clamped: Vec = @max(@min(them, ONE), ZERO);
+                const us1: Vec = us_acc[i..][0..VEC_SIZE].*;
+                const us1_clamped: Vec = @max(@min(us1, ONE), ZERO);
+                const us2: Vec = us_acc[i + HIDDEN_SIZE / 2 ..][0..VEC_SIZE].*;
+                const us2_clamped: Vec = @max(@min(us2, ONE), ZERO);
+
+                const them1: Vec = them_acc[i..][0..VEC_SIZE].*;
+                const them1_clamped: Vec = @max(@min(them1, ONE), ZERO);
+                const them2: Vec = them_acc[i + HIDDEN_SIZE / 2 ..][0..VEC_SIZE].*;
+                const them2_clamped: Vec = @max(@min(them2, ONE), ZERO);
 
                 const us_weights: Vec = (&weights.output_weights)[bucket_offset..][i..][0..VEC_SIZE].*;
-                const them_weights: Vec = (&weights.output_weights)[bucket_offset..][i + HIDDEN_SIZE ..][0..VEC_SIZE].*;
+                const them_weights: Vec = (&weights.output_weights)[bucket_offset..][i + HIDDEN_SIZE / 2 ..][0..VEC_SIZE].*;
 
                 acc.* +=
-                    madd(VEC_SIZE, mullo(VEC_SIZE, us_weights, us_clamped), us_clamped) +
-                    madd(VEC_SIZE, mullo(VEC_SIZE, them_weights, them_clamped), them_clamped);
+                    madd(VEC_SIZE, mullo(VEC_SIZE, us_weights, us1_clamped), us2_clamped) +
+                    madd(VEC_SIZE, mullo(VEC_SIZE, them_weights, them1_clamped), them2_clamped);
             }
         }
         var acc = accs[0];
@@ -358,9 +363,15 @@ const Accumulator = struct {
         var res: i32 = @reduce(std.builtin.ReduceOp.Add, acc);
         if (@import("builtin").mode == .Debug) {
             var verify_res: i32 = 0;
-            for (0..HIDDEN_SIZE) |j| {
-                verify_res += screlu(us_acc[j]) * (&weights.output_weights)[bucket_offset..][j];
-                verify_res += screlu(them_acc[j]) * (&weights.output_weights)[bucket_offset..][j + HIDDEN_SIZE];
+            for (0..HIDDEN_SIZE / 2) |j| {
+                verify_res +=
+                    crelu(us_acc[j]) *
+                    crelu(us_acc[j + HIDDEN_SIZE / 2]) *
+                    (&weights.output_weights)[bucket_offset..][j];
+                verify_res +=
+                    crelu(them_acc[j]) *
+                    crelu(them_acc[j + HIDDEN_SIZE / 2]) *
+                    (&weights.output_weights)[bucket_offset..][j + HIDDEN_SIZE / 2];
             }
             std.debug.assert(res == verify_res);
         }
@@ -517,6 +528,10 @@ pub fn evaluate(comptime stm: Colour, board: *const Board, eval_state: *State, r
     return eval_state.forward(stm, board, refresh_cache);
 }
 
+fn crelu(x: i32) i32 {
+    return std.math.clamp(x, 0, QA);
+}
+
 fn screlu(x: i32) i32 {
     const clamped = std.math.clamp(x, 0, QA);
     return clamped * clamped;
@@ -600,7 +615,7 @@ pub const HORIZONTAL_MIRRORING = true;
 pub const INPUT_BUCKET_COUNT: usize = 16;
 pub const OUTPUT_BUCKET_COUNT: usize = 8;
 pub const INPUT_SIZE: usize = 768;
-pub const HIDDEN_SIZE: usize = 1536;
+pub const HIDDEN_SIZE: usize = 2048;
 pub const SCALE = 400;
 pub const QA = 255;
 pub const QB = 64;

--- a/src/nnue.zig
+++ b/src/nnue.zig
@@ -571,7 +571,7 @@ const Accumulator = struct {
         }
 
         // in Q²
-        var l1_out_vec: [L2_SIZE / vecSize(i32)]i32Vec = undefined;
+        var l1_out_vec: [2 * L2_SIZE / vecSize(i32)]i32Vec = undefined;
         {
             const l1_bias_vec: [*]const i32Vec = @ptrCast(@alignCast(&(&weights.l1b)[output_bucket]));
             const SHIFT = comptime Q0_BITS * 2 - 9 + Q1_BITS - Q_BITS;
@@ -585,18 +585,21 @@ const Accumulator = struct {
 
                 // NOTE: PLEASE BE CAREFUL WITH THE QUANTISATION OF THESE BIASES
                 const shifted = intermediate + biases >> @splat(SHIFT);
-                const clamped = clamp(i32Vec, shifted, @splat(0), @splat(arch.Q));
-                const activated = clamped * clamped;
-                l1_out_vec[i] = activated;
+
+                const crelu = clamp(i32Vec, shifted, @splat(0), @splat(arch.Q)) << @splat(Q_BITS);
+                const csrelu = clamp(i32Vec, shifted * shifted, @splat(0), @splat(arch.Q * arch.Q));
+
+                l1_out_vec[i] = crelu;
+                l1_out_vec[i + L2_SIZE / vecSize(i32)] = csrelu;
             }
         }
 
         // in Q³
         var l2_intermediate: [L3_SIZE / vecSize(i32)]i32Vec = @bitCast((&weights.l2b)[output_bucket]);
         {
-            const l1_out: *const [L2_SIZE]i32 = @ptrCast(&l1_out_vec);
-            const l2_weight_vec: *const [L2_SIZE][L3_SIZE / vecSize(i32)]i32Vec = @ptrCast(@alignCast(&(&weights.l2w)[output_bucket]));
-            for (0..L2_SIZE) |i| {
+            const l1_out: *const [2 * L2_SIZE]i32 = @ptrCast(&l1_out_vec);
+            const l2_weight_vec: *const [2 * L2_SIZE][L3_SIZE / vecSize(i32)]i32Vec = @ptrCast(@alignCast(&(&weights.l2w)[output_bucket]));
+            for (0..L2_SIZE * 2) |i| {
                 const l1_vec: i32Vec = @splat(l1_out[i]);
                 for (0..L3_SIZE / vecSize(i32)) |j| {
                     l2_intermediate[j] += l1_vec * (&l2_weight_vec[i])[j];

--- a/src/nnue.zig
+++ b/src/nnue.zig
@@ -25,8 +25,32 @@ const Colour = root.Colour;
 const evaluation = root.evaluation;
 const Move = root.Move;
 
+const arch = @import("nnue_arch.zig");
+
+pub const Weights = arch.Weights;
+pub const HORIZONTAL_MIRRORING = arch.HORIZONTAL_MIRRORING;
+pub const INPUT_BUCKET_COUNT = arch.INPUT_BUCKET_COUNT;
+pub const OUTPUT_BUCKET_COUNT = arch.OUTPUT_BUCKET_COUNT;
+pub const INPUT_SIZE = arch.INPUT_SIZE;
+pub const L1_SIZE = arch.L1_SIZE;
+pub const L2_SIZE = arch.L2_SIZE;
+pub const L3_SIZE = arch.L3_SIZE;
+pub const SCALE = arch.SCALE;
+pub const Q = arch.Q;
+pub const Q0 = arch.Q0;
+pub const Q1 = arch.Q1;
+pub const Q_BITS = std.math.log2_int_ceil(u32, Q);
+pub const Q0_BITS = std.math.log2_int_ceil(u32, Q0);
+pub const Q1_BITS = std.math.log2_int_ceil(u32, Q1);
+pub const INPUT_BUCKET_LAYOUT = arch.INPUT_BUCKET_LAYOUT;
+
+pub const VEC_BYTES = arch.vecBytes(@import("builtin").cpu);
+
+fn vecSize(comptime T: type) comptime_int {
+    return VEC_BYTES / @sizeOf(T);
+}
+
 const builtin = @import("builtin");
-const CAN_VERBATIM_NET = builtin.cpu.arch.endian() == .little and builtin.mode == .ReleaseFast and !build_options.runtime_net;
 const build_options = @import("build_options");
 
 fn madd(
@@ -40,28 +64,6 @@ fn madd(
     const b1 = @as(@Vector(N / 2, i32), @intCast(std.simd.deinterlace(2, b)[1]));
     return (a0 * b0 + a1 * b1);
 }
-
-fn mullo(
-    comptime N: comptime_int,
-    a: @Vector(N, i16),
-    b: @Vector(N, i16),
-) @Vector(N, i16) {
-    return a *% b;
-}
-
-const Weights = extern struct {
-    hidden_layer_weights: [HIDDEN_SIZE * INPUT_SIZE * INPUT_BUCKET_COUNT]i16 align(std.atomic.cache_line),
-    hidden_layer_biases: [HIDDEN_SIZE]i16 align(std.atomic.cache_line),
-    output_weights: [HIDDEN_SIZE * OUTPUT_BUCKET_COUNT]i16 align(std.atomic.cache_line),
-    output_biases: [OUTPUT_BUCKET_COUNT]i16 align(std.atomic.cache_line),
-    const WEIGHT_COUNT = blk: {
-        var res = 0;
-        for (std.meta.fields(Weights)) |field| {
-            res += @typeInfo(field.type).array.len;
-        }
-        break :blk res;
-    };
-};
 
 pub inline fn whichInputBucket(stm: Colour, king_square: Square) usize {
     if (INPUT_BUCKET_COUNT == 1) {
@@ -78,19 +80,14 @@ pub inline fn whichOutputBucket(board: *const Board) usize {
 
 var weights_file: std.fs.File = undefined;
 var mapped_weights: []align(std.heap.pageSize()) const u8 = undefined;
-const verbatim_weights = if (CAN_VERBATIM_NET)
-blk: {
-    var res: Weights = undefined;
-    @memcpy(std.mem.asBytes(&res)[0 .. Weights.WEIGHT_COUNT * @sizeOf(i16)], @embedFile("net")[0 .. Weights.WEIGHT_COUNT * @sizeOf(i16)]);
-    break :blk res;
-} else undefined;
+var mapper: @import("MappedFile.zig") = undefined;
+const net = @embedFile("net");
+const verbatim_weights: [net.len:0]u8 align(64) = net.*;
 
-pub var weights = if (CAN_VERBATIM_NET) &verbatim_weights else if (build_options.runtime_net) @as(*const Weights, undefined) else &(struct {
-    var backing: Weights = undefined;
-}).backing;
-// @ptrCast(@alignCast(@as(*const anyopaque, @ptrCast(@embedFile("net")))));
-inline fn hiddenLayerWeightsVector() []const @Vector(VEC_SIZE, i16) {
-    return @as([*]const @Vector(VEC_SIZE, i16), @ptrCast(&weights.hidden_layer_weights))[0 .. weights.hidden_layer_weights.len / VEC_SIZE];
+pub var weights = @as(*const Weights, @ptrCast(&verbatim_weights));
+
+inline fn hiddenLayerWeightsVector() []const @Vector(vecSize(i16), i16) {
+    return @as([*]const @Vector(vecSize(i16), i16), @ptrCast(&weights.ft_w))[0 .. weights.ft_w.len / vecSize(i16)];
 }
 
 const SquarePieceType = struct {
@@ -136,12 +133,12 @@ pub fn idx(comptime perspective: Colour, comptime side: Colour, king_sq: Square,
 }
 
 fn vecIdx(comptime perspective: Colour, comptime side: Colour, king_sq: Square, tp: PieceType, sq: Square, mirror: MirroringType) usize {
-    return idx(perspective, side, king_sq, tp, sq, mirror) * HIDDEN_SIZE / VEC_SIZE;
+    return idx(perspective, side, king_sq, tp, sq, mirror) * L1_SIZE / vecSize(i16);
 }
 
 const Accumulator = struct {
-    white: [HIDDEN_SIZE]i16 align(std.atomic.cache_line),
-    black: [HIDDEN_SIZE]i16 align(std.atomic.cache_line),
+    white: [L1_SIZE]i16 align(std.atomic.cache_line),
+    black: [L1_SIZE]i16 align(std.atomic.cache_line),
 
     dirty_piece: DirtyPiece,
 
@@ -150,19 +147,19 @@ const Accumulator = struct {
 
     pub inline fn default() Accumulator {
         return .{
-            .white = weights.hidden_layer_biases,
-            .black = weights.hidden_layer_biases,
+            .white = weights.ft_b,
+            .black = weights.ft_b,
             .white_mirrored = .{},
             .black_mirrored = .{},
             .dirty_piece = .{},
         };
     }
 
-    inline fn accFor(self: anytype, col: Colour) root.inheritConstness(@TypeOf(self), *align(std.atomic.cache_line) [HIDDEN_SIZE]i16) {
+    inline fn accFor(self: anytype, col: Colour) root.inheritConstness(@TypeOf(self), *align(std.atomic.cache_line) [L1_SIZE]i16) {
         return if (col == .white) &self.white else &self.black;
     }
 
-    inline fn vecAccFor(self: anytype, col: Colour) root.inheritConstness(@TypeOf(self), *[HIDDEN_SIZE / VEC_SIZE]@Vector(VEC_SIZE, i16)) {
+    inline fn vecAccFor(self: anytype, col: Colour) root.inheritConstness(@TypeOf(self), *[L1_SIZE / vecSize(i16)]@Vector(vecSize(i16), i16)) {
         return @ptrCast(if (col == .white) &self.white else &self.black);
     }
 
@@ -217,7 +214,7 @@ const Accumulator = struct {
     fn doAdd(self: *Accumulator, comptime acc: Colour, comptime side: Colour, king_sq: Square, tp: PieceType, sq: Square) void {
         const add_idx = vecIdx(acc, side, king_sq, tp, sq, self.mirrorFor(acc));
 
-        for (0..HIDDEN_SIZE / VEC_SIZE) |i| {
+        for (0..L1_SIZE / vecSize(i16)) |i| {
             self.vecAccFor(acc)[i] += hiddenLayerWeightsVector()[add_idx + i];
         }
     }
@@ -226,7 +223,7 @@ const Accumulator = struct {
         const add_idx = vecIdx(acc, side, king_sq, add_tp, add_sq, self.mirrorFor(acc));
         const sub_idx = vecIdx(acc, side, king_sq, sub_tp, sub_sq, self.mirrorFor(acc));
 
-        for (0..HIDDEN_SIZE / VEC_SIZE) |i| {
+        for (0..L1_SIZE / vecSize(i16)) |i| {
             self.vecAccFor(acc)[i] += hiddenLayerWeightsVector()[add_idx + i] -
                 hiddenLayerWeightsVector()[sub_idx + i];
         }
@@ -236,7 +233,7 @@ const Accumulator = struct {
         const add_idx = vecIdx(acc, side, king_sq, add_tp, add_sq, self.mirrorFor(acc));
         const sub_idx = vecIdx(acc, side, king_sq, sub_tp, sub_sq, self.mirrorFor(acc));
         const opp_sub_idx = vecIdx(acc, side.flipped(), king_sq, opp_sub_tp, opp_sub_sq, self.mirrorFor(acc));
-        for (0..HIDDEN_SIZE / VEC_SIZE) |i| {
+        for (0..L1_SIZE / vecSize(i16)) |i| {
             self.vecAccFor(acc)[i] +=
                 hiddenLayerWeightsVector()[add_idx + i] -
                 hiddenLayerWeightsVector()[sub_idx + i] -
@@ -250,7 +247,7 @@ const Accumulator = struct {
         const add2_idx = vecIdx(acc, side, king_sq, add2_tp, add2_sq, self.mirrorFor(acc));
         const sub2_idx = vecIdx(acc, side, king_sq, sub2_tp, sub2_sq, self.mirrorFor(acc));
 
-        for (0..HIDDEN_SIZE / VEC_SIZE) |i| {
+        for (0..L1_SIZE / vecSize(i16)) |i| {
             self.vecAccFor(acc)[i] +=
                 hiddenLayerWeightsVector()[add1_idx + i] -
                 hiddenLayerWeightsVector()[sub1_idx + i] +
@@ -261,7 +258,7 @@ const Accumulator = struct {
     inline fn doAddCopy(self: *Accumulator, other: *const Accumulator, comptime acc: Colour, comptime side: Colour, king_sq: Square, tp: PieceType, sq: Square) void {
         const add_idx = vecIdx(acc, side, king_sq, tp, sq, self.mirrorFor(acc));
 
-        for (0..HIDDEN_SIZE / VEC_SIZE) |i| {
+        for (0..L1_SIZE / vecSize(i16)) |i| {
             self.vecAccFor(acc)[i] = other.vecAccFor(acc)[i] +
                 hiddenLayerWeightsVector()[add_idx + i];
         }
@@ -271,7 +268,7 @@ const Accumulator = struct {
         const add_idx = vecIdx(acc, side, king_sq, add_tp, add_sq, self.mirrorFor(acc));
         const sub_idx = vecIdx(acc, side, king_sq, sub_tp, sub_sq, self.mirrorFor(acc));
 
-        for (0..HIDDEN_SIZE / VEC_SIZE) |i| {
+        for (0..L1_SIZE / vecSize(i16)) |i| {
             self.vecAccFor(acc)[i] = other.vecAccFor(acc)[i] +
                 hiddenLayerWeightsVector()[add_idx + i] -
                 hiddenLayerWeightsVector()[sub_idx + i];
@@ -282,7 +279,7 @@ const Accumulator = struct {
         const add_idx = vecIdx(acc, side, king_sq, add_tp, add_sq, self.mirrorFor(acc));
         const sub_idx = vecIdx(acc, side, king_sq, sub_tp, sub_sq, self.mirrorFor(acc));
         const opp_sub_idx = vecIdx(acc, side.flipped(), king_sq, opp_sub_tp, opp_sub_sq, self.mirrorFor(acc));
-        for (0..HIDDEN_SIZE / VEC_SIZE) |i| {
+        for (0..L1_SIZE / vecSize(i16)) |i| {
             self.vecAccFor(acc)[i] = other.vecAccFor(acc)[i] +
                 hiddenLayerWeightsVector()[add_idx + i] -
                 hiddenLayerWeightsVector()[sub_idx + i] -
@@ -296,91 +293,13 @@ const Accumulator = struct {
         const add2_idx = vecIdx(acc, side, king_sq, add2_tp, add2_sq, self.mirrorFor(acc));
         const sub2_idx = vecIdx(acc, side, king_sq, sub2_tp, sub2_sq, self.mirrorFor(acc));
 
-        for (0..HIDDEN_SIZE / VEC_SIZE) |i| {
+        for (0..L1_SIZE / vecSize(i16)) |i| {
             self.vecAccFor(acc)[i] = other.vecAccFor(acc)[i] +
                 hiddenLayerWeightsVector()[add1_idx + i] -
                 hiddenLayerWeightsVector()[sub1_idx + i] +
                 hiddenLayerWeightsVector()[add2_idx + i] -
                 hiddenLayerWeightsVector()[sub2_idx + i];
         }
-    }
-
-    pub fn forward(noalias self: *Accumulator, comptime stm: Colour, board: *const Board, refresh_cache: anytype) i16 {
-        // std.debug.print("{any}\n", .{(&weights.hidden_layer_biases)[0..10]});
-        // std.debug.print("{any}\n", .{(&weights.output_biases)[0..BUCKET_COUNT]});
-
-        self.applyUpdate(.inplace, null, stm.flipped(), board, refresh_cache);
-        // std.debug.print("{any}\n", .{self.white[0..10]});
-        // std.debug.print("{any}\n", .{self.black[0..10]});
-        // if (std.debug.runtime_safety) {
-        //     const from_scratch = Accumulator.init(board);
-        //     std.testing.expectEqualDeep(from_scratch, self) catch |e| {
-        //         @import("main.zig").writeLog("{} {s}\n", .{ board.fullmove_clock * 2 + @intFromBool(board.turn == .black), board.toFen().slice() });
-        //         std.debug.panic("{} {s}\n", .{ e, board.toFen().slice() });
-        //     };
-        //     if (board.turn == .white) {
-        //         std.debug.assert(std.meta.eql(self.white, from_scratch.white));
-        //     } else {
-        //         std.debug.assert(std.meta.eql(self.black, from_scratch.black));
-        //     }
-        // }
-        const us_acc = if (board.stm == .white) &self.white else &self.black;
-        const them_acc = if (board.stm == .white) &self.black else &self.white;
-
-        //                vvvvvvvv annotation to help zls
-        const Vec = @as(type, @Vector(VEC_SIZE, i16));
-
-        const ACC_COUNT = comptime std.math.gcd(4, HIDDEN_SIZE / VEC_SIZE);
-        var accs = std.mem.zeroes([ACC_COUNT]@Vector(VEC_SIZE / 2, i32));
-        const ZERO: Vec = @splat(0);
-        const ONE: Vec = @splat(QA);
-        var i: usize = 0;
-        const which_bucket = whichOutputBucket(board);
-        const bucket_offset = which_bucket * HIDDEN_SIZE;
-        while (i < HIDDEN_SIZE / 2) {
-            inline for (&accs) |*acc| {
-                defer i += VEC_SIZE;
-                const us1: Vec = us_acc[i..][0..VEC_SIZE].*;
-                const us1_clamped: Vec = @max(@min(us1, ONE), ZERO);
-                const us2: Vec = us_acc[i + HIDDEN_SIZE / 2 ..][0..VEC_SIZE].*;
-                const us2_clamped: Vec = @max(@min(us2, ONE), ZERO);
-
-                const them1: Vec = them_acc[i..][0..VEC_SIZE].*;
-                const them1_clamped: Vec = @max(@min(them1, ONE), ZERO);
-                const them2: Vec = them_acc[i + HIDDEN_SIZE / 2 ..][0..VEC_SIZE].*;
-                const them2_clamped: Vec = @max(@min(them2, ONE), ZERO);
-
-                const us_weights: Vec = (&weights.output_weights)[bucket_offset..][i..][0..VEC_SIZE].*;
-                const them_weights: Vec = (&weights.output_weights)[bucket_offset..][i + HIDDEN_SIZE / 2 ..][0..VEC_SIZE].*;
-
-                acc.* +=
-                    madd(VEC_SIZE, mullo(VEC_SIZE, us_weights, us1_clamped), us2_clamped) +
-                    madd(VEC_SIZE, mullo(VEC_SIZE, them_weights, them1_clamped), them2_clamped);
-            }
-        }
-        var acc = accs[0];
-        for (accs[1..]) |tmp| acc += tmp;
-        var res: i32 = @reduce(std.builtin.ReduceOp.Add, acc);
-        if (@import("builtin").mode == .Debug) {
-            var verify_res: i32 = 0;
-            for (0..HIDDEN_SIZE / 2) |j| {
-                verify_res +=
-                    crelu(us_acc[j]) *
-                    crelu(us_acc[j + HIDDEN_SIZE / 2]) *
-                    (&weights.output_weights)[bucket_offset..][j];
-                verify_res +=
-                    crelu(them_acc[j]) *
-                    crelu(them_acc[j + HIDDEN_SIZE / 2]) *
-                    (&weights.output_weights)[bucket_offset..][j + HIDDEN_SIZE / 2];
-            }
-            std.debug.assert(res == verify_res);
-        }
-        res = @divTrunc(res, QA); // res /= QA
-
-        res += (&weights.output_biases)[which_bucket];
-        const scaled = @divTrunc(res * SCALE, QA * QB);
-
-        return evaluation.clampScore(scaled);
     }
 
     fn needsRefresh(stm: Colour, from: Square, to: Square) bool {
@@ -411,21 +330,6 @@ const Accumulator = struct {
             return;
         }
         defer self.dirty_piece = .{};
-        // std.debug.print("--------\n", .{});
-        // std.debug.print("{}\n", .{stm});
-        // defer if (@import("builtin").mode == .Debug) {
-        //     const correct = Accumulator.init(board);
-        //     if (!std.meta.eql(correct.white, self.white)) {
-        //         unreachable;
-        //     }
-        //     if (!std.meta.eql(correct.black, self.black)) {
-        //         unreachable;
-        //     }
-        // };
-        // {
-        //     self.initInPlace(board);
-        //     return;
-        // }
         const copy = if (mode == .inplace) self else other;
         const us_king_sq = Square.fromBitboard(board.kingFor(stm));
         const them_king_sq = Square.fromBitboard(board.kingFor(stm.flipped()));
@@ -509,93 +413,214 @@ const Accumulator = struct {
         self.dirty_piece.subs.appendAssumeCapacity(.{ .pt = sub1_pt, .sq = sub1_square });
         self.dirty_piece.subs.appendAssumeCapacity(.{ .pt = sub2_pt, .sq = sub2_square });
     }
-};
 
-// export fn addExp(self: *Accumulator, tp: *PieceType, sq: *Square) void {
-//     const ptr = &weights;
-//     std.mem.doNotOptimizeAway(ptr);
-//     self.add(.white, tp.*, sq.*);
-// }
-// export fn addSubExp(self: *Accumulator, addtp: *PieceType, addsq: *Square, subtp: *PieceType, subsq: *Square) void {
-//     const ptr = &weights;
-//     std.mem.doNotOptimizeAway(ptr);
-//     self.addSub(.white, addtp.*, addsq.*, subtp.*, subsq.*);
-// }
+    pub fn forward(noalias self: *Accumulator, comptime stm: Colour, board: *const Board, refresh_cache: anytype) i16 {
+        self.applyUpdate(.inplace, null, stm.flipped(), board, refresh_cache);
+        std.debug.assert(board.stm == stm);
+        // if (true)
+        //     return 0;
+        const stm_acc = self.accFor(stm);
+        const ntm_acc = self.accFor(stm.flipped());
+        // const stm_vec = self.vecAccFor(stm);
+        // const ntm_vec = self.vecAccFor(stm.flipped());
+        // //             vvvvvvvv annotation to help zls
+        const i8Vec = @as(type, @Vector(vecSize(i8), i8));
+        const i16Vec = @as(type, @Vector(vecSize(i16), i16));
+        const i32Vec = @as(type, @Vector(vecSize(i32), i32));
+        const u8Vec = @as(type, @Vector(vecSize(u8), u8));
+        // const u16Vec = @as(type, @Vector(vecSize(u16), u16));
+        // const u32Vec = @as(type, @Vector(vecSize(u32), u32));
+
+        const c = struct {
+            fn maddubs(u: u8Vec, i: i8Vec) i16Vec {
+                return asm ("vpmaddubsw %[i], %[u], %[ret]"
+                    : [ret] "=x" (-> i16Vec),
+                    : [u] "x" (u),
+                      [i] "x" (i),
+                );
+            }
+
+            fn maddwd(a: i16Vec, b: i16Vec) i32Vec {
+                return asm ("vpmaddwd %[b], %[a], %[ret]"
+                    : [ret] "=x" (-> i32Vec),
+                    : [a] "x" (a),
+                      [b] "x" (b),
+                );
+            }
+
+            fn dpbusd(sum: i32Vec, u: u8Vec, i: i8Vec) i32Vec {
+                if (builtin.cpu.has(.x86, .avx512vnni) and false) {
+                    var s = sum;
+                    asm ("vpdpbusd %[i], %[u], %[s]"
+                        : [s] "+x" (s),
+                        : [u] "x" (u),
+                          [i] "x" (i),
+                    );
+                    return s;
+                } else {
+                    const partial_sums = maddubs(u, i);
+
+                    const ones: i16Vec = @splat(1);
+                    const dot_products = maddwd(partial_sums, ones);
+
+                    return sum + dot_products;
+                }
+            }
+
+            fn mulhi(a: i16Vec, b: i16Vec) i16Vec {
+                return asm ("vpmulhw %[b], %[a], %[ret]"
+                    : [ret] "=x" (-> i16Vec),
+                    : [a] "x" (a),
+                      [b] "x" (b),
+                );
+            }
+            fn packus(a: i16Vec, b: i16Vec) u8Vec {
+                return asm ("vpackuswb %[b], %[a], %[ret]"
+                    : [ret] "=x" (-> u8Vec),
+                    : [a] "x" (a),
+                      [b] "x" (b),
+                );
+            }
+        };
+        const clamp = struct {
+            fn impl(comptime T: type, x: T, lo: T, hi: T) T {
+                return @min(@max(x, lo), hi);
+            }
+        }.impl;
+
+        const output_bucket = whichOutputBucket(board);
+
+        // in Q0² / 2⁹
+        var activated_ft: [L1_SIZE]u8 align(64) = undefined;
+        {
+            const items_per_iter = vecSize(i16) * 2;
+            var i: usize = 0;
+            const LO: i16Vec = @splat(0);
+            const HI: i16Vec = @splat(arch.Q0);
+            while (i < L1_SIZE / 2) : (i += items_per_iter) {
+                var s1: i16Vec = stm_acc[i..][0..vecSize(i16)].*;
+                var s2: i16Vec = stm_acc[i + L1_SIZE / 2 ..][0..vecSize(i16)].*;
+                var s3: i16Vec = stm_acc[i + vecSize(i16) ..][0..vecSize(i16)].*;
+                var s4: i16Vec = stm_acc[i + vecSize(i16) + L1_SIZE / 2 ..][0..vecSize(i16)].*;
+
+                var n1: i16Vec = ntm_acc[i..][0..vecSize(i16)].*;
+                var n2: i16Vec = ntm_acc[i + L1_SIZE / 2 ..][0..vecSize(i16)].*;
+                var n3: i16Vec = ntm_acc[i + vecSize(i16) ..][0..vecSize(i16)].*;
+                var n4: i16Vec = ntm_acc[i + vecSize(i16) + L1_SIZE / 2 ..][0..vecSize(i16)].*;
+
+                s1 = clamp(i16Vec, s1, LO, HI);
+                s2 = @min(s2, HI);
+                s3 = clamp(i16Vec, s3, LO, HI);
+                s4 = @min(s4, HI);
+
+                n1 = clamp(i16Vec, n1, LO, HI);
+                n2 = @min(n2, HI);
+                n3 = clamp(i16Vec, n3, LO, HI);
+                n4 = @min(n4, HI);
+
+                const sp1 = c.mulhi(s1 << @splat(7), s2);
+                const sp2 = c.mulhi(s3 << @splat(7), s4);
+
+                const np1 = c.mulhi(n1 << @splat(7), n2);
+                const np2 = c.mulhi(n3 << @splat(7), n4);
+
+                const p1: [vecSize(u8)]u8 = c.packus(sp1, sp2);
+                const p2: [vecSize(u8)]u8 = c.packus(np1, np2);
+
+                @memcpy(activated_ft[i..][0..vecSize(i8)], &p1);
+                @memcpy(activated_ft[i + L1_SIZE / 2 ..][0..vecSize(i8)], &p2);
+            }
+        }
+
+        const L2_UNROLL = 4;
+        // in Q0² / 2⁹ * Q1
+        var l1_intermediate: [L2_SIZE / vecSize(i32)][L2_UNROLL]i32Vec = @splat(@splat(@splat(0)));
+        {
+            const w: [*]const i8 = &(&weights.l1w)[output_bucket];
+            const ft_i32: [*]i32 = @ptrCast(&activated_ft);
+            var i_outer: usize = 0;
+            while (i_outer + L2_UNROLL <= L1_SIZE / 4) : (i_outer += L2_UNROLL) {
+                for (0..L2_SIZE / vecSize(i32)) |j| {
+                    for (0..L2_UNROLL) |i_inner| {
+                        const i = i_outer + i_inner;
+                        const ft_vec: u8Vec = @bitCast(@as(i32Vec, @splat(ft_i32[i])));
+                        l1_intermediate[j][i_inner] = c.dpbusd(
+                            l1_intermediate[j][i_inner],
+                            ft_vec,
+                            w[i * L2_SIZE * 4 + j * vecSize(i8) ..][0..vecSize(i8)].*,
+                        );
+                    }
+                }
+            }
+            while (i_outer < L1_SIZE / 4) : (i_outer += 1) {
+                const ft_vec: u8Vec = @bitCast(@as(i32Vec, @splat(ft_i32[i_outer])));
+
+                for (0..L2_SIZE / vecSize(i32)) |j| {
+                    const i = i_outer;
+                    l1_intermediate[j][0] = c.dpbusd(
+                        l1_intermediate[j][0],
+                        ft_vec,
+                        w[i * L2_SIZE * 4 + j * vecSize(i8) ..][0..vecSize(i8)].*,
+                    );
+                }
+            }
+        }
+
+        // in Q²
+        var l1_out_vec: [L2_SIZE / vecSize(i32)]i32Vec = undefined;
+        {
+            const l1_bias_vec: [*]const i32Vec = @ptrCast(@alignCast(&(&weights.l1b)[output_bucket]));
+            const SHIFT = comptime Q0_BITS * 2 - 9 + Q1_BITS - Q_BITS;
+            for (0..L2_SIZE / vecSize(i32)) |i| {
+                const biases: i32Vec = l1_bias_vec[i];
+
+                var intermediate: i32Vec = @splat(0);
+                for (l1_intermediate[i]) |e| {
+                    intermediate += e;
+                }
+
+                // NOTE: PLEASE BE CAREFUL WITH THE QUANTISATION OF THESE BIASES
+                const shifted = intermediate + biases >> @splat(SHIFT);
+                const clamped = clamp(i32Vec, shifted, @splat(0), @splat(arch.Q));
+                const activated = clamped * clamped;
+                l1_out_vec[i] = activated;
+            }
+        }
+
+        // in Q³
+        var l2_intermediate: [L3_SIZE / vecSize(i32)]i32Vec = @bitCast((&weights.l2b)[output_bucket]);
+        {
+            const l1_out: *const [L2_SIZE]i32 = @ptrCast(&l1_out_vec);
+            const l2_weight_vec: *const [L2_SIZE][L3_SIZE / vecSize(i32)]i32Vec = @ptrCast(@alignCast(&(&weights.l2w)[output_bucket]));
+            for (0..L2_SIZE) |i| {
+                const l1_vec: i32Vec = @splat(l1_out[i]);
+                for (0..L3_SIZE / vecSize(i32)) |j| {
+                    l2_intermediate[j] += l1_vec * (&l2_weight_vec[i])[j];
+                }
+            }
+        }
+
+        // in Q⁴
+        var l3_sum: i32Vec = @splat(0);
+        {
+            const l3_weight_vec: *const [L3_SIZE / vecSize(i32)]i32Vec = @ptrCast(@alignCast(&(&weights.l3w)[output_bucket]));
+            for (0..L3_SIZE / vecSize(i32)) |i| {
+                const activated = clamp(i32Vec, l2_intermediate[i], @splat(0), @splat(arch.Q * arch.Q * arch.Q));
+                l3_sum += activated * l3_weight_vec[i];
+            }
+        }
+
+        const bias = (&weights.l3b)[output_bucket];
+        const scaled = (@reduce(.Add, l3_sum) + bias) * SCALE;
+
+        return evaluation.clampScore(@divTrunc(scaled, arch.Q * arch.Q * arch.Q * arch.Q));
+    }
+};
 
 pub const State = Accumulator;
 
 pub fn evaluate(comptime stm: Colour, board: *const Board, eval_state: *State, refresh_cache: anytype) i16 {
     return eval_state.forward(stm, board, refresh_cache);
-}
-
-fn crelu(x: i32) i32 {
-    return std.math.clamp(x, 0, QA);
-}
-
-fn screlu(x: i32) i32 {
-    const clamped = std.math.clamp(x, 0, QA);
-    return clamped * clamped;
-}
-
-pub fn init() !void {
-    if (build_options.runtime_net) {
-        weights_file = std.fs.openFileAbsolute(build_options.net_path, .{}) catch try std.fs.cwd().openFile(build_options.net_name, .{});
-        if (@import("builtin").target.os.tag == .windows) {
-            @compileError("sorry mmap-ing the network manually is not supported on windows");
-        }
-        mapped_weights = try std.posix.mmap(null, Weights.WEIGHT_COUNT * @sizeOf(i16), std.posix.PROT.READ, .{ .TYPE = .PRIVATE }, weights_file.handle, 0);
-
-        weights = @ptrCast(mapped_weights.ptr);
-
-        return;
-    }
-
-    if (CAN_VERBATIM_NET) {
-        return;
-    }
-
-    var fbs = std.Io.Reader.fixed(@embedFile("net"));
-
-    // first read the weights for the first layer (there should be HIDDEN_SIZE * INPUT_SIZE of them)
-    for (0..(&weights.hidden_layer_weights).len) |i| {
-        var buf: [2]u8 = undefined;
-        std.debug.assert(fbs.readSliceShort(&buf) catch unreachable == 2);
-        (&weights.hidden_layer_weights)[i] = std.mem.readInt(i16, &buf, .little);
-    }
-
-    // then the biases for the first layer (there should be HIDDEN_SIZE of them)
-    for (0..(&weights.hidden_layer_biases).len) |i| {
-        var buf: [2]u8 = undefined;
-        std.debug.assert(fbs.readSliceShort(&buf) catch unreachable == 2);
-        (&weights.hidden_layer_biases)[i] = std.mem.readInt(i16, &buf, .little);
-    }
-
-    // then the weights for the second layer (there should be HIDDEN_SIZE * 2 of them)
-    for (0..(&weights.output_weights).len) |i| {
-        var buf: [2]u8 = undefined;
-        std.debug.assert(fbs.readSliceShort(&buf) catch unreachable == 2);
-        (&weights.output_weights)[i] = std.mem.readInt(i16, &buf, .little);
-    }
-
-    // then finally the bias(es)
-    for (0..(&weights.output_biases).len) |i| {
-        var buf: [2]u8 = undefined;
-        std.debug.assert(fbs.readSliceShort(&buf) catch unreachable == 2);
-        (&weights.output_biases)[i] = std.mem.readInt(i16, &buf, .little);
-    }
-    // std.debug.print("{any}\n", .{(&weights.hidden_layer_biases)});
-}
-
-pub fn deinit() void {
-    if (CAN_VERBATIM_NET) {
-        return;
-    }
-    if (!build_options.runtime_net) {
-        return;
-    }
-
-    weights_file.close();
-    std.posix.munmap(mapped_weights);
 }
 
 pub fn evalPosition(board: *const Board) i16 {
@@ -609,23 +634,3 @@ pub fn evalPosition(board: *const Board) i16 {
         },
     }
 }
-
-pub const VEC_SIZE = @min(HIDDEN_SIZE & -%HIDDEN_SIZE, 2 * (std.simd.suggestVectorLength(i16) orelse 8));
-pub const HORIZONTAL_MIRRORING = true;
-pub const INPUT_BUCKET_COUNT: usize = 16;
-pub const OUTPUT_BUCKET_COUNT: usize = 8;
-pub const INPUT_SIZE: usize = 768;
-pub const HIDDEN_SIZE: usize = 2048;
-pub const SCALE = 400;
-pub const QA = 255;
-pub const QB = 64;
-pub const INPUT_BUCKET_LAYOUT: [64]u8 = .{
-    0,  1,  2,  3,  3,  2,  1,  0,
-    4,  5,  6,  7,  7,  6,  5,  4,
-    8,  8,  9,  9,  9,  9,  8,  8,
-    10, 10, 11, 11, 11, 11, 10, 10,
-    12, 12, 13, 13, 13, 13, 12, 12,
-    12, 12, 13, 13, 13, 13, 12, 12,
-    14, 14, 15, 15, 15, 15, 14, 14,
-    14, 14, 15, 15, 15, 15, 14, 14,
-};

--- a/src/nnue_arch.zig
+++ b/src/nnue_arch.zig
@@ -22,7 +22,7 @@ pub const Weights = extern struct {
     ft_b: [L1_SIZE]i16 align(ALIGNMENT),
     l1w: [OUTPUT_BUCKET_COUNT][L2_SIZE * L1_SIZE]i8 align(ALIGNMENT),
     l1b: [OUTPUT_BUCKET_COUNT][L2_SIZE]i32 align(ALIGNMENT),
-    l2w: [OUTPUT_BUCKET_COUNT][L3_SIZE * L2_SIZE]i32 align(ALIGNMENT),
+    l2w: [OUTPUT_BUCKET_COUNT][2 * L3_SIZE * L2_SIZE]i32 align(ALIGNMENT),
     l2b: [OUTPUT_BUCKET_COUNT][L3_SIZE]i32 align(ALIGNMENT),
     l3w: [OUTPUT_BUCKET_COUNT][L3_SIZE]i32 align(ALIGNMENT),
     l3b: [OUTPUT_BUCKET_COUNT]i32 align(ALIGNMENT),
@@ -35,11 +35,11 @@ pub const Weights = extern struct {
         return @ptrCast(&self.l1w);
     }
 
-    fn l2wInference(self: *Weights) *align(64) [OUTPUT_BUCKET_COUNT][L3_SIZE * L2_SIZE]i32 {
+    fn l2wInference(self: *Weights) *align(64) [OUTPUT_BUCKET_COUNT][2 * L3_SIZE * L2_SIZE]i32 {
         return @ptrCast(&self.l2w);
     }
 
-    fn l2wDisk(self: *Weights) *align(64) [L2_SIZE][OUTPUT_BUCKET_COUNT][L3_SIZE]i32 {
+    fn l2wDisk(self: *Weights) *align(64) [2 * L2_SIZE][OUTPUT_BUCKET_COUNT][L3_SIZE]i32 {
         return @ptrCast(&self.l2w);
     }
 
@@ -228,14 +228,14 @@ pub fn permuteNet(cpu: std.Target.Cpu, net: *Weights) void {
 
     // transpose l2w
     {
-        // [L2_SIZE][OUTPUT_BUCKET_COUNT][L3_SIZE]i32
+        // [2 * L2_SIZE][OUTPUT_BUCKET_COUNT][L3_SIZE]i32
         const l2w_disk = net.l2wDisk().*;
 
-        // [OUTPUT_BUCKET_COUNT][L3_SIZE * L2_SIZE]i32
+        // [OUTPUT_BUCKET_COUNT][2 * L3_SIZE * L2_SIZE]i32
         const l2w_inf = net.l2wInference();
 
         for (0..OUTPUT_BUCKET_COUNT) |ob| {
-            for (0..L2_SIZE) |i| {
+            for (0..2 * L2_SIZE) |i| {
                 for (0..L3_SIZE) |j| {
                     l2w_inf[ob][i * L3_SIZE + j] = l2w_disk[i][ob][j];
                 }

--- a/src/nnue_arch.zig
+++ b/src/nnue_arch.zig
@@ -1,0 +1,281 @@
+// pawnocchio, UCI chess engine
+// Copyright (C) 2025 Jonathan Hallström
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+const std = @import("std");
+const builtin = @import("builtin");
+
+const ALIGNMENT = 64;
+pub const Weights = extern struct {
+    ft_w: [L1_SIZE * INPUT_SIZE * INPUT_BUCKET_COUNT]i16 align(ALIGNMENT),
+    ft_b: [L1_SIZE]i16 align(ALIGNMENT),
+    l1w: [OUTPUT_BUCKET_COUNT][L2_SIZE * L1_SIZE]i8 align(ALIGNMENT),
+    l1b: [OUTPUT_BUCKET_COUNT][L2_SIZE]i32 align(ALIGNMENT),
+    l2w: [OUTPUT_BUCKET_COUNT][L3_SIZE * L2_SIZE]i32 align(ALIGNMENT),
+    l2b: [OUTPUT_BUCKET_COUNT][L3_SIZE]i32 align(ALIGNMENT),
+    l3w: [OUTPUT_BUCKET_COUNT][L3_SIZE]i32 align(ALIGNMENT),
+    l3b: [OUTPUT_BUCKET_COUNT]i32 align(ALIGNMENT),
+
+    fn l1wInference(self: *Weights) *align(64) [OUTPUT_BUCKET_COUNT][L2_SIZE * L1_SIZE]i8 {
+        return @ptrCast(&self.l1w);
+    }
+
+    fn l1wDisk(self: *Weights) *align(64) [L1_SIZE][OUTPUT_BUCKET_COUNT][L2_SIZE]i8 {
+        return @ptrCast(&self.l1w);
+    }
+
+    fn l2wInference(self: *Weights) *align(64) [OUTPUT_BUCKET_COUNT][L3_SIZE * L2_SIZE]i32 {
+        return @ptrCast(&self.l2w);
+    }
+
+    fn l2wDisk(self: *Weights) *align(64) [L2_SIZE][OUTPUT_BUCKET_COUNT][L3_SIZE]i32 {
+        return @ptrCast(&self.l2w);
+    }
+
+    fn l3wInference(self: *Weights) *align(64) [OUTPUT_BUCKET_COUNT][L3_SIZE]i32 {
+        return @ptrCast(&self.l3w);
+    }
+
+    fn l3wDisk(self: *Weights) *align(64) [L3_SIZE][OUTPUT_BUCKET_COUNT]i32 {
+        return @ptrCast(&self.l3w);
+    }
+
+    pub const WEIGHT_COUNT = blk: {
+        var res = 0;
+        for (std.meta.fields(Weights)) |field| {
+            res += @typeInfo(field.type).array.len;
+        }
+        break :blk res;
+    };
+    pub const SIZE_BYTES = blk: {
+        var res = 0;
+        for (std.meta.fields(Weights)) |field| {
+            const array_info = @typeInfo(field.type).array;
+            res += array_info.len * @sizeOf(array_info.child);
+        }
+        break :blk res;
+    };
+};
+
+pub fn vecBytes(comptime cpu: std.Target.Cpu) comptime_int {
+    if (cpu.has(.x86, .avx512f)) {
+        return 64;
+    }
+    if (cpu.has(.x86, .avx2)) {
+        return 32;
+    }
+    if (cpu.has(.arm, .neon)) {
+        return 16;
+    }
+    return 1;
+}
+
+const LONGEST_PERMUTE_LEN = 8;
+
+pub fn permuteOrder(cpu: std.Target.Cpu) []const u8 {
+    if (cpu.has(.x86, .avx512f)) {
+        return &[_]u8{ 0, 2, 4, 6, 1, 3, 5, 7 };
+    }
+    if (cpu.has(.x86, .avx2)) {
+        return &[_]u8{ 0, 2, 1, 3 };
+    }
+    if (cpu.has(.arm, .neon)) {
+        return &[_]u8{0};
+    }
+    return &[_]u8{};
+}
+
+pub fn needsPermuting(cpu: std.Target.Cpu) bool {
+    if (cpu.has(.x86, .avx512f)) {
+        return true;
+    }
+    if (cpu.has(.x86, .avx2)) {
+        return true;
+    }
+    if (cpu.has(.arm, .neon)) {
+        return false;
+    }
+    return false;
+}
+
+pub fn hasSupportedSimd(cpu: std.Target.Cpu) bool {
+    if (cpu.has(.x86, .avx512f)) {
+        return true;
+    }
+    if (cpu.has(.x86, .avx2)) {
+        return true;
+    }
+    if (cpu.has(.arm, .neon)) {
+        return true;
+    }
+    return false;
+}
+
+pub fn permuteBuffer(ptr: anytype, order: anytype) void {
+    const Block = @Vector(16, u8);
+
+    const num_blocks = @sizeOf(@TypeOf(ptr.*)) / @sizeOf(Block);
+    const vecs: *[num_blocks]Block = @ptrCast(ptr);
+
+    var i: usize = 0;
+    var weights: [LONGEST_PERMUTE_LEN]Block = undefined;
+    while (i < num_blocks) : (i += order.len) {
+        @memcpy(weights[0..order.len], vecs[i..][0..order.len]);
+
+        for (0..order.len) |j| {
+            vecs[i + j] = weights[order[j]];
+        }
+    }
+}
+
+fn UltimateChild(comptime T: type) type {
+    const info = @typeInfo(T);
+
+    switch (info) {
+        inline else => |i| {
+            if (@hasField(@TypeOf(i), "child")) {
+                return UltimateChild(i.child);
+            }
+            return T;
+        },
+    }
+}
+
+fn totalElements(comptime T: type) comptime_int {
+    const info = @typeInfo(T);
+
+    switch (info) {
+        .array => |i| {
+            return i.len * totalElements(i.child);
+        },
+        inline else => |i| {
+            if (!@hasField(@TypeOf(i), "child")) {
+                return 1;
+            }
+            return totalElements(i.child);
+        },
+    }
+}
+
+pub fn permuteNet(cpu: std.Target.Cpu, net: *Weights) void {
+    if (needsPermuting(cpu)) {
+        inline for (.{ &net.ft_w, &net.ft_b }) |ptr| {
+            permuteBuffer(ptr, permuteOrder(cpu));
+        }
+    }
+
+    if (cpu.arch.endian() != .little) {
+        inline for (.{
+            &net.ft_w,
+            &net.ft_b,
+            &net.l1w,
+            &net.l1b,
+            &net.l2w,
+            &net.l2b,
+            &net.l3w,
+            &net.l3b,
+        }) |field| {
+            const T = UltimateChild(@TypeOf(field));
+
+            const Int = std.meta.Int(.unsigned, @bitSizeOf(T));
+
+            const p: *[totalElements(@TypeOf(field))]T = @ptrCast(field);
+            for (p) |*e| {
+                e.* = @bitCast(@byteSwap(@as(Int, @bitCast(e.*))));
+            }
+        }
+    }
+
+    // permute l1w for dpbusd
+    {
+        // [L1_SIZE][OUTPUT_BUCKET_COUNT][L2_SIZE]i8
+        const l1w_disk = net.l1wDisk().*;
+
+        // [OUTPUT_BUCKET_COUNT][L2_SIZE * L1_SIZE]i8
+        const l1w_inf = net.l1wInference();
+
+        if (hasSupportedSimd(cpu)) {
+            for (0..OUTPUT_BUCKET_COUNT) |ob| {
+                for (0..L1_SIZE / 4) |i| {
+                    for (0..L2_SIZE) |j| {
+                        for (0..4) |k| {
+                            l1w_inf[ob][i * 4 * L2_SIZE + j * 4 + k] = l1w_disk[i * 4 + k][ob][j];
+                        }
+                    }
+                }
+            }
+        } else {
+            for (0..OUTPUT_BUCKET_COUNT) |ob| {
+                for (0..L1_SIZE) |i| {
+                    for (0..L2_SIZE) |j| {
+                        l1w_inf[ob][i * L2_SIZE + j] = l1w_disk[i][ob][j];
+                    }
+                }
+            }
+        }
+    }
+
+    // transpose l2w
+    {
+        // [L2_SIZE][OUTPUT_BUCKET_COUNT][L3_SIZE]i32
+        const l2w_disk = net.l2wDisk().*;
+
+        // [OUTPUT_BUCKET_COUNT][L3_SIZE * L2_SIZE]i32
+        const l2w_inf = net.l2wInference();
+
+        for (0..OUTPUT_BUCKET_COUNT) |ob| {
+            for (0..L2_SIZE) |i| {
+                for (0..L3_SIZE) |j| {
+                    l2w_inf[ob][i * L3_SIZE + j] = l2w_disk[i][ob][j];
+                }
+            }
+        }
+    }
+    // transpose l3w
+    {
+        // [L3_SIZE][OUTPUT_BUCKET_COUNT]i32
+        const l3w_disk = net.l3wDisk().*;
+
+        // [OUTPUT_BUCKET_COUNT][L3_SIZE]i32
+        const l3w_inf = net.l3wInference();
+
+        for (0..OUTPUT_BUCKET_COUNT) |ob| {
+            for (0..L3_SIZE) |i| {
+                l3w_inf[ob][i] = l3w_disk[i][ob];
+            }
+        }
+    }
+}
+
+pub const HORIZONTAL_MIRRORING = true;
+pub const INPUT_BUCKET_COUNT: usize = 16;
+pub const OUTPUT_BUCKET_COUNT: usize = 8;
+pub const INPUT_SIZE: usize = 768;
+pub const L1_SIZE: usize = 2048;
+pub const L2_SIZE: usize = 16;
+pub const L3_SIZE: usize = 32;
+pub const SCALE: i64 = 400;
+pub const Q0 = 255;
+pub const Q1 = 128;
+pub const Q = 64;
+pub const INPUT_BUCKET_LAYOUT: [64]u8 = .{
+    0,  1,  2,  3,  3,  2,  1,  0,
+    4,  5,  6,  7,  7,  6,  5,  4,
+    8,  8,  9,  9,  9,  9,  8,  8,
+    10, 10, 11, 11, 11, 11, 10, 10,
+    12, 12, 13, 13, 13, 13, 12, 12,
+    12, 12, 13, 13, 13, 13, 12, 12,
+    14, 14, 15, 15, 15, 15, 14, 14,
+    14, 14, 15, 15, 15, 15, 14, 14,
+};

--- a/src/nnue_arch.zig
+++ b/src/nnue_arch.zig
@@ -134,7 +134,7 @@ pub fn permuteBuffer(ptr: anytype, order: anytype) void {
         @memcpy(weights[0..order.len], vecs[i..][0..order.len]);
 
         for (0..order.len) |j| {
-            vecs[i + j] = weights[order[j]];
+            vecs[i + j] = (&weights)[order[j]];
         }
     }
 }
@@ -242,6 +242,7 @@ pub fn permuteNet(cpu: std.Target.Cpu, net: *Weights) void {
             }
         }
     }
+
     // transpose l3w
     {
         // [L3_SIZE][OUTPUT_BUCKET_COUNT]i32

--- a/src/refresh_cache.zig
+++ b/src/refresh_cache.zig
@@ -24,7 +24,7 @@ const Colour = root.Colour;
 const nnue = @import("nnue.zig");
 
 const NNCacheEntry = struct {
-    accumulator: [nnue.HIDDEN_SIZE]i16,
+    accumulator: [nnue.L1_SIZE]i16,
     pieces: [6]u64,
     sides: [2]u64,
 
@@ -58,33 +58,33 @@ const NNCacheEntry = struct {
             }
         }
         while (num_adds >= 4) : (num_adds -= 4) {
-            for (0..nnue.HIDDEN_SIZE) |i| {
+            for (0..nnue.L1_SIZE) |i| {
                 self.accumulator[i] +=
-                    (&nnue.weights.hidden_layer_weights)[adds[num_adds - 4] * nnue.HIDDEN_SIZE + i] +
-                    (&nnue.weights.hidden_layer_weights)[adds[num_adds - 3] * nnue.HIDDEN_SIZE + i] +
-                    (&nnue.weights.hidden_layer_weights)[adds[num_adds - 2] * nnue.HIDDEN_SIZE + i] +
-                    (&nnue.weights.hidden_layer_weights)[adds[num_adds - 1] * nnue.HIDDEN_SIZE + i];
+                    (&nnue.weights.ft_w)[adds[num_adds - 4] * nnue.L1_SIZE + i] +
+                    (&nnue.weights.ft_w)[adds[num_adds - 3] * nnue.L1_SIZE + i] +
+                    (&nnue.weights.ft_w)[adds[num_adds - 2] * nnue.L1_SIZE + i] +
+                    (&nnue.weights.ft_w)[adds[num_adds - 1] * nnue.L1_SIZE + i];
             }
         }
         while (num_adds >= 1) : (num_adds -= 1) {
-            for (0..nnue.HIDDEN_SIZE) |i| {
+            for (0..nnue.L1_SIZE) |i| {
                 self.accumulator[i] +=
-                    (&nnue.weights.hidden_layer_weights)[adds[num_adds - 1] * nnue.HIDDEN_SIZE + i];
+                    (&nnue.weights.ft_w)[adds[num_adds - 1] * nnue.L1_SIZE + i];
             }
         }
         while (num_subs >= 4) : (num_subs -= 4) {
-            for (0..nnue.HIDDEN_SIZE) |i| {
+            for (0..nnue.L1_SIZE) |i| {
                 self.accumulator[i] -=
-                    (&nnue.weights.hidden_layer_weights)[subs[num_subs - 4] * nnue.HIDDEN_SIZE + i] +
-                    (&nnue.weights.hidden_layer_weights)[subs[num_subs - 3] * nnue.HIDDEN_SIZE + i] +
-                    (&nnue.weights.hidden_layer_weights)[subs[num_subs - 2] * nnue.HIDDEN_SIZE + i] +
-                    (&nnue.weights.hidden_layer_weights)[subs[num_subs - 1] * nnue.HIDDEN_SIZE + i];
+                    (&nnue.weights.ft_w)[subs[num_subs - 4] * nnue.L1_SIZE + i] +
+                    (&nnue.weights.ft_w)[subs[num_subs - 3] * nnue.L1_SIZE + i] +
+                    (&nnue.weights.ft_w)[subs[num_subs - 2] * nnue.L1_SIZE + i] +
+                    (&nnue.weights.ft_w)[subs[num_subs - 1] * nnue.L1_SIZE + i];
             }
         }
         while (num_subs >= 1) : (num_subs -= 1) {
-            for (0..nnue.HIDDEN_SIZE) |i| {
+            for (0..nnue.L1_SIZE) |i| {
                 self.accumulator[i] -=
-                    (&nnue.weights.hidden_layer_weights)[subs[num_subs - 1] * nnue.HIDDEN_SIZE + i];
+                    (&nnue.weights.ft_w)[subs[num_subs - 1] * nnue.L1_SIZE + i];
             }
         }
         self.pieces = board.pieces;
@@ -105,7 +105,7 @@ pub fn refreshCache(comptime mirrored: bool, comptime bucket_count: usize) type 
             for (&self.data) |*stm| {
                 for (stm) |*subarray| {
                     for (subarray) |*e| {
-                        @memcpy(&e.accumulator, &nnue.weights.hidden_layer_biases);
+                        @memcpy(&e.accumulator, &nnue.weights.ft_b);
                         @memset(&e.pieces, 0);
                         @memset(&e.sides, 0);
                     }

--- a/src/sparse.zig
+++ b/src/sparse.zig
@@ -1,0 +1,78 @@
+// pawnocchio, UCI chess engine
+// Copyright (C) 2025 Jonathan Hallström
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+const attack_array_generation = @import("attack_array_generation.zig");
+const root = @import("root.zig");
+const Square = root.Square;
+const Bitboard = root.Bitboard;
+
+const nnue = @import("nnue.zig");
+
+const L1_SIZE = nnue.L1_SIZE;
+
+const NONZERO_INDICES = blk: {
+    var res: [256]@Vector(8, u16) = @splat(@splat(0));
+
+    @setEvalBranchQuota(256 * 8 * 2);
+    for (0..256) |i| {
+        var count = 0;
+        for (0..8) |j| {
+            if (i & 1 << j != 0) {
+                res[i][count] = j;
+                count += 1;
+            }
+        }
+    }
+    break :blk res;
+};
+
+fn getMask(vals: @Vector(nnue.vecSize(u8), u8)) std.meta.Int(.unsigned, nnue.vecSize(i32)) {
+    const as_i32: @Vector(nnue.vecSize(i32), i32) = @bitCast(vals);
+    const zero: @Vector(nnue.vecSize(i32), i32) = @splat(0);
+
+    return @bitCast(as_i32 != zero);
+}
+
+pub inline fn findNonZeroIndices(
+    ft: *align(64) const [L1_SIZE]u8,
+) struct {
+    [L1_SIZE / 4]u16,
+    usize,
+} {
+    var indices: [L1_SIZE / 4]u16 = undefined;
+    var count: usize = 0;
+    var base: @Vector(8, u16) = @splat(0);
+
+    var i: usize = 0;
+    while (i < nnue.L1_SIZE) : (i += nnue.vecSize(u8)) {
+        const mask = getMask(ft[i..][0..nnue.vecSize(i8)].*);
+
+        inline for (0..nnue.vecSize(i32) / 8) |j| {
+            const byte = mask >> (8 * j) & 0xff;
+
+            const mask_indices = NONZERO_INDICES[byte];
+
+            const actual_indices: [8]u16 = mask_indices + base;
+            @memcpy(indices[count..][0..8], &actual_indices);
+
+            count += @popCount(byte);
+            base += @splat(8);
+        }
+    }
+
+    return .{ indices, count };
+}


### PR DESCRIPTION
```
Elo   | -1.65 +- 2.77 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | -1.87 (-2.25, 2.89) [0.00, 3.00]
Games | N: 15960 W: 3875 L: 3951 D: 8134
Penta | [61, 1919, 4083, 1869, 48]
```
https://furybench.com/test/4853/

```
Elo   | 4.16 +- 2.57 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16616 W: 4047 L: 3848 D: 8721
Penta | [13, 1820, 4435, 2035, 5]
```
https://furybench.com/test/4855/