### PR TITLE
retrain at 1.0WDL

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
     const name = b.option([]const u8, "name", "Change the name of the binary") orelse "pawnocchio";
 
-    const net_name = "mixed_data_dualact.nnue";
+    const net_name = "mixed_data_dualact_higher_wdl.nnue";
 
     const net = b.option([]const u8, "net", "Change the net to be used") orelse blk: {
         break :blk "pawnocchio-nets/networks/" ++ net_name;


### PR DESCRIPTION
```
Elo   | -1.65 +- 2.77 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | -1.87 (-2.25, 2.89) [0.00, 3.00]
Games | N: 15960 W: 3875 L: 3951 D: 8134
Penta | [61, 1919, 4083, 1869, 48]
```
https://furybench.com/test/4853/

```
Elo   | 4.16 +- 2.57 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16616 W: 4047 L: 3848 D: 8721
Penta | [13, 1820, 4435, 2035, 5]
```
https://furybench.com/test/4855/