### PR TITLE
Sparser net

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
     const name = b.option([]const u8, "name", "Change the name of the binary") orelse "pawnocchio";
 
-    const net_name = "mixed_data_dualact_higher_wdl.nnue";
+    const net_name = "mixed_data_sparse.nnue";
 
     const net = b.option([]const u8, "net", "Change the net to be used") orelse blk: {
         break :blk "pawnocchio-nets/networks/" ++ net_name;


### PR DESCRIPTION
```
Elo   | 7.93 +- 4.31 (95%)
SPRT  | N=20000 Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11486 W: 3712 L: 3450 D: 4324
Penta | [283, 1294, 2409, 1392, 365]
```
https://furybench.com/test/4924/

```
Elo   | 10.47 +- 4.39 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 3.00]
Games | N: 6338 W: 1682 L: 1491 D: 3165
Penta | [20, 661, 1616, 852, 20]
```
https://furybench.com/test/4921/

```
Elo   | 8.07 +- 3.79 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 7882 W: 1981 L: 1798 D: 4103
Penta | [3, 849, 2065, 1010, 14]
```
https://furybench.com/test/4922/

bench: 2783961