### PR TITLE
turn alpha raise reduction into an lmr term

### DIFF
--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -949,6 +949,7 @@ fn search(
     var num_searched: u8 = 0;
     self.stackEntry(1).failhighs = 0;
     var num_legal: u8 = 0;
+    var alpha_raises: u8 = 0;
     const lmp_base = if (improving) tunables.lmp_improving_base else tunables.lmp_standard_base;
     const lmp_linear_mult = if (improving) tunables.lmp_improving_linear_mult else tunables.lmp_standard_linear_mult;
     const lmp_quadratic_mult = if (improving) tunables.lmp_improving_quadratic_mult else tunables.lmp_standard_quadratic_mult;
@@ -1187,6 +1188,7 @@ fn search(
                     is_root,
                     cur.failhighs > 2,
                 });
+                reduction += @as(i32, 1024) * alpha_raises;
 
                 const raw_reduced_depth = depth + extension - (reduction >> 10);
                 const reduced_depth = std.math.clamp(raw_reduced_depth, 1, new_depth + @intFromBool(is_pv));
@@ -1315,9 +1317,7 @@ fn search(
                 }
                 break;
             }
-            if (2 <= depth and depth <= 12) {
-                depth -= 1;
-            }
+            alpha_raises += 1;
         }
     }
 

--- a/src/tuning.zig
+++ b/src/tuning.zig
@@ -140,6 +140,7 @@ const tunable_defaults = struct {
     pub const lmr_quiet_history_mult: i32 = 891;
     pub const lmr_noisy_history_mult: i32 = 896;
     pub const lmr_corrhist_mult: i32 = 8219;
+    pub const lmr_alpha_raise_mult: i32 = 1024;
     pub const lmr_dodeeper_margin: i32 = 59457;
     pub const lmr_dodeeper_mult: i32 = 1997;
     pub const lmr_doshallower_margin: i32 = 1153;
@@ -329,6 +330,7 @@ pub const tunables = [_]Tunable{
     .{ .name = "lmr_quiet_history_mult", .default = tunable_defaults.lmr_quiet_history_mult, .min = -10, .max = 1975, .c_end = 78 },
     .{ .name = "lmr_noisy_history_mult", .default = tunable_defaults.lmr_noisy_history_mult, .min = -10, .max = 2470, .c_end = 98 },
     .{ .name = "lmr_corrhist_mult", .default = tunable_defaults.lmr_corrhist_mult, .min = -10, .max = 23695, .c_end = 947 },
+    .{ .name = "lmr_alpha_raise_mult", .default = tunable_defaults.lmr_alpha_raise_mult },
     .{ .name = "lmr_dodeeper_margin", .default = tunable_defaults.lmr_dodeeper_margin },
     .{ .name = "lmr_dodeeper_mult", .default = tunable_defaults.lmr_dodeeper_mult },
     .{ .name = "lmr_doshallower_margin", .default = tunable_defaults.lmr_doshallower_margin },
@@ -518,6 +520,7 @@ pub const tunable_constants = if (do_tuning) struct {
     pub var lmr_quiet_history_mult = tunable_defaults.lmr_quiet_history_mult;
     pub var lmr_noisy_history_mult = tunable_defaults.lmr_noisy_history_mult;
     pub var lmr_corrhist_mult = tunable_defaults.lmr_corrhist_mult;
+    pub var lmr_alpha_raise_mult = tunable_defaults.lmr_alpha_raise_mult;
     pub var lmr_dodeeper_margin = tunable_defaults.lmr_dodeeper_margin;
     pub var lmr_dodeeper_mult = tunable_defaults.lmr_dodeeper_mult;
     pub var lmr_doshallower_margin = tunable_defaults.lmr_doshallower_margin;


### PR DESCRIPTION
```
Elo   | 1.85 +- 2.50 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 19204 W: 4692 L: 4590 D: 9922
Penta | [58, 2207, 4970, 2309, 58]
```
https://furybench.com/test/5105/

```
Elo   | 0.10 +- 3.26 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.34 (-2.25, 2.89) [0.00, 3.00]
Games | N: 10420 W: 2440 L: 2437 D: 5543
Penta | [11, 1200, 2785, 1203, 11]
```
https://furybench.com/test/5106/

bench: 4237311