### PR TITLE
Fail firm in QS

### DIFF
--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -544,6 +544,10 @@ fn qsearch(
         }
     }
 
+    if (!evaluation.isTBScore(best_score) and !evaluation.isTBScore(beta) and best_score > beta) {
+        best_score = @intCast(@divTrunc(best_score + beta, 2));
+    }
+
     self.writeTT(
         tt_pv,
         tt_hash,

--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -545,7 +545,12 @@ fn qsearch(
     }
 
     if (!evaluation.isTBScore(best_score) and !evaluation.isTBScore(beta) and best_score > beta) {
-        best_score = @intCast(@divTrunc(best_score + beta, 2));
+        // best_score = @intCast(@divTrunc(best_score + beta, 2));
+        best_score = @intCast(@divTrunc(
+            best_score * (1024 - tunables.qs_fail_medium) +
+                beta * tunables.qs_fail_medium,
+            1024,
+        ));
     }
 
     self.writeTT(

--- a/src/tuning.zig
+++ b/src/tuning.zig
@@ -221,6 +221,7 @@ const tunable_defaults = struct {
     pub const tt_fail_medium: i32 = 11;
     pub const qs_tt_fail_medium: i32 = 181;
     pub const standpat_fail_medium: i32 = 290;
+    pub const qs_fail_medium: i32 = 512;
     pub const nodetm_base: i32 = 1418;
     pub const nodetm_mult: i32 = 1178;
     pub const eval_stab_margin: i32 = 22;
@@ -411,6 +412,7 @@ pub const tunables = [_]Tunable{
     .{ .name = "tt_fail_medium", .default = tunable_defaults.tt_fail_medium, .min = 0, .max = 1024, .c_end = 128 },
     .{ .name = "qs_tt_fail_medium", .default = tunable_defaults.qs_tt_fail_medium, .min = 0, .max = 1024, .c_end = 128 },
     .{ .name = "standpat_fail_medium", .default = tunable_defaults.standpat_fail_medium, .min = 0, .max = 1024, .c_end = 128 },
+    .{ .name = "qs_fail_medium", .default = tunable_defaults.qs_fail_medium, .min = 0, .max = 1024, .c_end = 128 },
     .{ .name = "nodetm_base", .default = tunable_defaults.nodetm_base, .min = 1024, .c_end = 40 },
     .{ .name = "nodetm_mult", .default = tunable_defaults.nodetm_mult, .min = 10, .c_end = 25 },
     .{ .name = "eval_stab_margin", .default = tunable_defaults.eval_stab_margin, .min = 1, .c_end = 0.5 },
@@ -601,6 +603,7 @@ pub const tunable_constants = if (do_tuning) struct {
     pub var tt_fail_medium = tunable_defaults.tt_fail_medium;
     pub var qs_tt_fail_medium = tunable_defaults.qs_tt_fail_medium;
     pub var standpat_fail_medium = tunable_defaults.standpat_fail_medium;
+    pub var qs_fail_medium = tunable_defaults.qs_fail_medium;
     pub var nodetm_base = tunable_defaults.nodetm_base;
     pub var nodetm_mult = tunable_defaults.nodetm_mult;
     pub var eval_stab_margin = tunable_defaults.eval_stab_margin;


### PR DESCRIPTION
```
Elo   | 1.30 +- 1.03 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 114258 W: 27786 L: 27359 D: 59113
Penta | [340, 13475, 29095, 13856, 363]
```
https://furybench.com/test/5158/

```
Elo   | 1.50 +- 1.35 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.37 (-2.25, 2.89) [0.00, 3.00]
Games | N: 60586 W: 14233 L: 13972 D: 32381
Penta | [39, 6875, 16222, 7100, 57]
```
https://furybench.com/test/5160/