### PR TITLE
ttpv lmr adjustments

### DIFF
--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -1214,6 +1214,11 @@ fn search(
                 });
                 reduction += @as(i32, tunables.lmr_alpha_raise_mult) * alpha_raises;
 
+                if (tt_pv) {
+                    reduction -= @as(i32, 512) * @intFromBool(tt_entry.flags.score_type != .none and tt_entry.score > alpha);
+                    reduction -= @as(i32, 512) * @intFromBool(tt_entry.flags.score_type != .none and tt_entry.depth >= depth);
+                }
+
                 const raw_reduced_depth = depth + extension - (reduction >> 10);
                 const reduced_depth = std.math.clamp(raw_reduced_depth, 1, new_depth + @intFromBool(is_pv));
                 self.stackEntry(0).reduction =

--- a/src/tuning.zig
+++ b/src/tuning.zig
@@ -141,6 +141,8 @@ const tunable_defaults = struct {
     pub const lmr_noisy_history_mult: i32 = 896;
     pub const lmr_corrhist_mult: i32 = 8219;
     pub const lmr_alpha_raise_mult: i32 = 1024;
+    pub const lmr_ttpv_depth: i32 = 512;
+    pub const lmr_ttpv_score: i32 = 512;
     pub const lmr_dodeeper_margin: i32 = 59457;
     pub const lmr_dodeeper_mult: i32 = 1997;
     pub const lmr_doshallower_margin: i32 = 1153;
@@ -332,6 +334,8 @@ pub const tunables = [_]Tunable{
     .{ .name = "lmr_noisy_history_mult", .default = tunable_defaults.lmr_noisy_history_mult, .min = -10, .max = 2470, .c_end = 98 },
     .{ .name = "lmr_corrhist_mult", .default = tunable_defaults.lmr_corrhist_mult, .min = -10, .max = 23695, .c_end = 947 },
     .{ .name = "lmr_alpha_raise_mult", .default = tunable_defaults.lmr_alpha_raise_mult },
+    .{ .name = "lmr_ttpv_depth", .default = tunable_defaults.lmr_ttpv_depth },
+    .{ .name = "lmr_ttpv_score", .default = tunable_defaults.lmr_ttpv_score },
     .{ .name = "lmr_dodeeper_margin", .default = tunable_defaults.lmr_dodeeper_margin },
     .{ .name = "lmr_dodeeper_mult", .default = tunable_defaults.lmr_dodeeper_mult },
     .{ .name = "lmr_doshallower_margin", .default = tunable_defaults.lmr_doshallower_margin },
@@ -523,6 +527,8 @@ pub const tunable_constants = if (do_tuning) struct {
     pub var lmr_noisy_history_mult = tunable_defaults.lmr_noisy_history_mult;
     pub var lmr_corrhist_mult = tunable_defaults.lmr_corrhist_mult;
     pub var lmr_alpha_raise_mult = tunable_defaults.lmr_alpha_raise_mult;
+    pub var lmr_ttpv_depth = tunable_defaults.lmr_ttpv_depth;
+    pub var lmr_ttpv_score = tunable_defaults.lmr_ttpv_score;
     pub var lmr_dodeeper_margin = tunable_defaults.lmr_dodeeper_margin;
     pub var lmr_dodeeper_mult = tunable_defaults.lmr_dodeeper_mult;
     pub var lmr_doshallower_margin = tunable_defaults.lmr_doshallower_margin;


### PR DESCRIPTION
```
Elo   | 1.75 +- 1.41 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 61150 W: 15017 L: 14709 D: 31424
Penta | [180, 7182, 15548, 7480, 185]
```
https://furybench.com/test/5252/

fuck it

bench: 4516553