### PR TITLE
lmr extension in pv nodes

### DIFF
--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -1215,7 +1215,7 @@ fn search(
                 reduction += @as(i32, tunables.lmr_alpha_raise_mult) * alpha_raises;
 
                 const raw_reduced_depth = depth + extension - (reduction >> 10);
-                const reduced_depth = std.math.clamp(raw_reduced_depth, 1, new_depth + @intFromBool(is_pv));
+                const reduced_depth = std.math.clamp(raw_reduced_depth, 1, new_depth) + @intFromBool(is_pv);
                 self.stackEntry(0).reduction =
                     if (raw_reduced_depth == reduced_depth)
                         reduction


### PR DESCRIPTION
```
Elo   | 1.13 +- 0.84 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.02 (-2.25, 2.89) [0.00, 3.00]
Games | N: 174324 W: 42347 L: 41782 D: 90195
Penta | [512, 20531, 44537, 21044, 538]
```
https://furybench.com/test/5246/
bench: 5888903