### PR TITLE
Eval optimism

### DIFF
--- a/src/Board.zig
+++ b/src/Board.zig
@@ -168,6 +168,28 @@ pub fn classicalMaterial(self: Board) u8 {
     return self.sumPieces([_]u8{ 1, 3, 3, 5, 9, 0 });
 }
 
+pub fn materialScale(self: Board) i32 {
+    const tunables = root.tunable_constants;
+    @setEvalBranchQuota(1 << 30);
+    const vals: [6]i16 = if (root.tuning.do_tuning) .{
+        @intCast(tunables.material_scaling_pawn),
+        @intCast(tunables.material_scaling_knight),
+        @intCast(tunables.material_scaling_bishop),
+        @intCast(tunables.material_scaling_rook),
+        @intCast(tunables.material_scaling_queen),
+        0,
+    } else comptime .{
+        tunables.material_scaling_pawn,
+        tunables.material_scaling_knight,
+        tunables.material_scaling_bishop,
+        tunables.material_scaling_rook,
+        tunables.material_scaling_queen,
+        0,
+    };
+
+    return self.sumPieces(vals);
+}
+
 pub fn parseFen(ifen: []const u8, permissive: bool) !Board {
     const fen = std.mem.trim(u8, ifen, &std.ascii.whitespace);
     if (std.ascii.eqlIgnoreCase(fen, "startpos")) return startpos();

--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -1629,7 +1629,10 @@ pub fn startSearch(self: *Searcher, params: Params, is_main_thread: bool, quiet:
         const depth: i32 = @intCast(d);
         self.limits.root_depth = depth;
         const best_avg: i32 = @intCast(@divTrunc(average_score + previous_score, 2));
-        const optimism = @divTrunc(169 * best_avg, @as(i32, @intCast(@abs(best_avg))) + 187);
+        const optimism = @divTrunc(
+            tunables.optimism_root_mult * best_avg,
+            @as(i32, @intCast(@abs(best_avg))) + tunables.optimism_root_offs,
+        );
         self.optimism[params.board.stm.toInt()] = optimism;
         self.optimism[params.board.stm.flipped().toInt()] = -optimism;
         var quantized_window: i64 = tunables.aspiration_initial + (average_score * tunables.aspiration_score_mult >> 14);

--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -110,6 +110,7 @@ root_move: ?Move,
 root_score: ?i16,
 full_width_score: i16,
 full_width_score_normalized: i16,
+optimism: [2]i32,
 nodes_prev_check: u64,
 eval_stability: u8,
 move_stability: u8,
@@ -558,7 +559,13 @@ fn qsearch(
     var static_eval = corrected_static_eval;
     if (!is_in_check) {
         raw_static_eval = if (tt_hit and !evaluation.isMateScore(tt_entry.raw_static_eval)) tt_entry.raw_static_eval else self.rawEval(stm);
-        correction, corrected_static_eval = self.histories.correct(board, cur.move, cur.prev, self.applyContempt(raw_static_eval));
+        correction, corrected_static_eval = self.histories.correct(
+            board,
+            cur.move,
+            cur.prev,
+            self.applyContempt(raw_static_eval),
+            self.optimism[board.stm.toInt()],
+        );
         cur.corrected_eval = corrected_static_eval;
         cur.evals = cur.evals.updateWith(stm, corrected_static_eval);
         static_eval = corrected_static_eval;
@@ -804,7 +811,13 @@ fn search(
     var is_tt_corrected_eval = false;
     if (!is_in_check and !is_singular_search) {
         raw_static_eval = if (tt_hit and !evaluation.isMateScore(tt_entry.raw_static_eval)) tt_entry.raw_static_eval else self.rawEval(stm);
-        correction, corrected_static_eval = self.histories.correct(board, cur.move, cur.prev, self.applyContempt(raw_static_eval));
+        correction, corrected_static_eval = self.histories.correct(
+            board,
+            cur.move,
+            cur.prev,
+            self.applyContempt(raw_static_eval),
+            self.optimism[board.stm.toInt()],
+        );
         cur.corrected_eval = corrected_static_eval;
         cur.evals = cur.evals.updateWith(stm, corrected_static_eval);
         improving = cur.evals.improving(stm);
@@ -1610,10 +1623,15 @@ pub fn startSearch(self: *Searcher, params: Params, is_main_thread: bool, quiet:
     self.eval_stability = 0;
     self.move_stability = 0;
     self.full_width_score = 0;
+    self.optimism = .{ 0, 0 };
     var average_score: i64 = 0;
     for (1..MAX_PLY) |d| {
         const depth: i32 = @intCast(d);
         self.limits.root_depth = depth;
+        const best_avg: i32 = @intCast(@divTrunc(average_score + previous_score, 2));
+        const optimism = @divTrunc(169 * best_avg, @as(i32, @intCast(@abs(best_avg))) + 187);
+        self.optimism[params.board.stm.toInt()] = optimism;
+        self.optimism[params.board.stm.flipped().toInt()] = -optimism;
         var quantized_window: i64 = tunables.aspiration_initial + (average_score * tunables.aspiration_score_mult >> 14);
         if (d == 1) {
             quantized_window = @as(i32, evaluation.inf_score) << 10;

--- a/src/history.zig
+++ b/src/history.zig
@@ -667,7 +667,8 @@ pub const HistoryTable = struct {
         const material = board.materialScale();
         const material_scaled = @as(i64, eval) * (tunables.material_scaling_base + material);
         divisor *= 16384;
-        const optimism_scaled = material_scaled * 64 + optimism * (66560 + 51 * material);
+        const optimism_scaled = material_scaled * 64 +
+            optimism * (tunables.optimism_eval_base + tunables.optimism_eval_material_mult * material);
         divisor *= 64;
         const fifty_move_rule_scaled = optimism_scaled * (200 - board.halfmove);
         divisor *= 200;

--- a/src/history.zig
+++ b/src/history.zig
@@ -639,6 +639,7 @@ pub const HistoryTable = struct {
         prev: TypedMove,
         followup: TypedMove,
         static_eval: i16,
+        optimism: i32,
     ) struct { i16, i16 } {
         const pawn_correction = self.pawn_corrhist.read(board);
         const major_correction = self.major_corrhist.read(board);
@@ -656,36 +657,22 @@ pub const HistoryTable = struct {
             tunables.corrhist_major_weight * major_correction +
             tunables.corrhist_minor_weight * minor_correction) >> 18;
 
-        const scaled = scaleEval(board, static_eval);
+        const scaled = scaleEval(board, static_eval, optimism);
 
         return .{ @intCast(correction), evaluation.clampScore(scaled + correction) };
     }
 
-    pub fn scaleEval(board: *const Board, eval: i16) i16 {
+    pub fn scaleEval(board: *const Board, eval: i16, optimism: i64) i16 {
         comptime var divisor = 1;
-        const fifty_move_rule_scaled = @as(i64, eval) * (200 - board.halfmove);
-        divisor *= 200;
-        @setEvalBranchQuota(1 << 30);
-        const vals: [6]i16 = if (root.tuning.do_tuning) .{
-            @intCast(tunables.material_scaling_pawn),
-            @intCast(tunables.material_scaling_knight),
-            @intCast(tunables.material_scaling_bishop),
-            @intCast(tunables.material_scaling_rook),
-            @intCast(tunables.material_scaling_queen),
-            0,
-        } else comptime .{
-            tunables.material_scaling_pawn,
-            tunables.material_scaling_knight,
-            tunables.material_scaling_bishop,
-            tunables.material_scaling_rook,
-            tunables.material_scaling_queen,
-            0,
-        };
-
-        const material_scaled = fifty_move_rule_scaled * (tunables.material_scaling_base + board.sumPieces(vals));
+        const material = board.materialScale();
+        const material_scaled = @as(i64, eval) * (tunables.material_scaling_base + material);
         divisor *= 16384;
+        const optimism_scaled = material_scaled * 64 + optimism * (66560 + 51 * material);
+        divisor *= 64;
+        const fifty_move_rule_scaled = optimism_scaled * (200 - board.halfmove);
+        divisor *= 200;
 
-        return @intCast(@divTrunc(material_scaled, divisor));
+        return @intCast(@divTrunc(fifty_move_rule_scaled, divisor));
     }
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -656,7 +656,7 @@ pub fn main() !void {
             std.debug.print("average: {d:.4} average abs: {d:.4}\n", .{ average, abs_average });
         } else if (root.evaluation.eval_mode == .nnue and std.ascii.eqlIgnoreCase(command, "nneval")) {
             const raw_eval = root.nnue.evalPosition(&board);
-            const scaled = root.history.HistoryTable.scaleEval(&board, raw_eval);
+            const scaled = root.history.HistoryTable.scaleEval(&board, raw_eval, 0);
             const normalized = root.wdl.normalize(scaled, board.classicalMaterial());
             write("raw eval: {}\n", .{raw_eval});
             write("scaled eval: {}\n", .{scaled});

--- a/src/tuning.zig
+++ b/src/tuning.zig
@@ -359,6 +359,10 @@ const tunable_defaults = struct {
     pub const material_scaling_bishop: i32 = 511;
     pub const material_scaling_rook: i32 = 281;
     pub const material_scaling_queen: i32 = 974;
+    pub const optimism_root_mult: i32 = 169;
+    pub const optimism_root_offs: i32 = 187;
+    pub const optimism_eval_base: i32 = 66560;
+    pub const optimism_eval_material_mult: i32 = 51;
     pub const rfp_fail_medium: i32 = 62;
     pub const tt_fail_medium: i32 = 11;
     pub const qs_tt_fail_medium: i32 = 181;
@@ -588,6 +592,10 @@ pub const tunables = [_]Tunable{
     .{ .name = "material_scaling_bishop", .default = tunable_defaults.material_scaling_bishop, .min = 10, .max = 1007, .c_end = 39 },
     .{ .name = "material_scaling_rook", .default = tunable_defaults.material_scaling_rook, .min = 10, .max = 1360, .c_end = 54 },
     .{ .name = "material_scaling_queen", .default = tunable_defaults.material_scaling_queen, .min = 10, .max = 2495, .c_end = 99 },
+    .{ .name = "optimism_root_mult", .default = tunable_defaults.optimism_root_mult },
+    .{ .name = "optimism_root_offs", .default = tunable_defaults.optimism_root_offs },
+    .{ .name = "optimism_eval_base", .default = tunable_defaults.optimism_eval_base },
+    .{ .name = "optimism_eval_material_mult", .default = tunable_defaults.optimism_eval_material_mult },
     .{ .name = "rfp_fail_medium", .default = tunable_defaults.rfp_fail_medium, .min = 0, .max = 1024, .c_end = 128 },
     .{ .name = "tt_fail_medium", .default = tunable_defaults.tt_fail_medium, .min = 0, .max = 1024, .c_end = 128 },
     .{ .name = "qs_tt_fail_medium", .default = tunable_defaults.qs_tt_fail_medium, .min = 0, .max = 1024, .c_end = 128 },
@@ -817,6 +825,10 @@ pub const tunable_constants = if (do_tuning) struct {
     pub var material_scaling_bishop = tunable_defaults.material_scaling_bishop;
     pub var material_scaling_rook = tunable_defaults.material_scaling_rook;
     pub var material_scaling_queen = tunable_defaults.material_scaling_queen;
+    pub var optimism_root_mult = tunable_defaults.optimism_root_mult;
+    pub var optimism_root_offs = tunable_defaults.optimism_root_offs;
+    pub var optimism_eval_base = tunable_defaults.optimism_eval_base;
+    pub var optimism_eval_material_mult = tunable_defaults.optimism_eval_material_mult;
     pub var rfp_fail_medium = tunable_defaults.rfp_fail_medium;
     pub var tt_fail_medium = tunable_defaults.tt_fail_medium;
     pub var qs_tt_fail_medium = tunable_defaults.qs_tt_fail_medium;


### PR DESCRIPTION
```
Elo   | 5.15 +- 3.00 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 3.00]
Games | N: 14504 W: 3754 L: 3539 D: 7211
Penta | [69, 1642, 3633, 1821, 87]
```
https://furybench.com/test/5314/

```
Elo   | 3.15 +- 3.32 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 1.25 (-2.25, 2.89) [0.00, 3.00]
Games | N: 10490 W: 2576 L: 2481 D: 5433
Penta | [18, 1194, 2724, 1293, 16]
```
https://furybench.com/test/5316/

bench: 5622439