### PR TITLE
Also update corrhist when bestmove is a bad capture

### DIFF
--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -1398,7 +1398,10 @@ fn search(
             raw_static_eval,
         );
 
-        if (!is_in_check and (best_score <= alpha_original or board.isQuiet(best_move))) {
+        if (!is_in_check and (best_score <= alpha_original or
+            board.isQuiet(best_move) or
+            !SEE.scoreMove(board, best_move, 0, .pruning)))
+        {
             if (corrected_static_eval != best_score and
                 evaluation.checkTTBound(best_score, corrected_static_eval, corrected_static_eval, score_type))
             {

--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -110,7 +110,6 @@ root_move: ?Move,
 root_score: ?i16,
 full_width_score: i16,
 full_width_score_normalized: i16,
-optimism: [2]i32,
 nodes_prev_check: u64,
 eval_stability: u8,
 move_stability: u8,
@@ -555,7 +554,6 @@ fn qsearch(
             cur.move,
             cur.prev,
             self.applyContempt(raw_static_eval),
-            self.optimism[board.stm.toInt()],
         );
         cur.corrected_eval = corrected_static_eval;
         cur.evals = cur.evals.updateWith(stm, corrected_static_eval);
@@ -806,7 +804,6 @@ fn search(
             cur.move,
             cur.prev,
             self.applyContempt(raw_static_eval),
-            self.optimism[board.stm.toInt()],
         );
         cur.corrected_eval = corrected_static_eval;
         cur.evals = cur.evals.updateWith(stm, corrected_static_eval);
@@ -1620,18 +1617,10 @@ pub fn startSearch(self: *Searcher, params: Params, is_main_thread: bool, quiet:
     self.eval_stability = 0;
     self.move_stability = 0;
     self.full_width_score = 0;
-    self.optimism = .{ 0, 0 };
     var average_score: i64 = 0;
     for (1..MAX_PLY) |d| {
         const depth: i32 = @intCast(d);
         self.limits.root_depth = depth;
-        const best_avg: i32 = @intCast(@divTrunc(average_score + previous_score, 2));
-        const optimism = @divTrunc(
-            tunables.optimism_root_mult * best_avg,
-            @as(i32, @intCast(@abs(best_avg))) + tunables.optimism_root_offs,
-        );
-        self.optimism[params.board.stm.toInt()] = optimism;
-        self.optimism[params.board.stm.flipped().toInt()] = -optimism;
         var quantized_window: i64 = tunables.aspiration_initial + (average_score * tunables.aspiration_score_mult >> 14);
         if (d == 1) {
             quantized_window = @as(i32, evaluation.inf_score) << 10;

--- a/src/history.zig
+++ b/src/history.zig
@@ -635,7 +635,6 @@ pub const HistoryTable = struct {
         prev: TypedMove,
         followup: TypedMove,
         static_eval: i16,
-        optimism: i32,
     ) struct { i16, i16 } {
         const pawn_correction = self.pawn_corrhist.read(board);
         const major_correction = self.major_corrhist.read(board);
@@ -653,20 +652,20 @@ pub const HistoryTable = struct {
             tunables.corrhist_major_weight * major_correction +
             tunables.corrhist_minor_weight * minor_correction) >> 18;
 
-        const scaled = scaleEval(board, static_eval, optimism);
+        const scaled = scaleEval(board, static_eval);
 
         return .{ @intCast(correction), evaluation.clampScore(scaled + correction) };
     }
 
-    pub fn scaleEval(board: *const Board, eval: i16, optimism: i64) i16 {
+    pub fn scaleEval(
+        board: *const Board,
+        eval: i16,
+    ) i16 {
         comptime var divisor = 1;
         const material = board.materialScale();
         const material_scaled = @as(i64, eval) * (tunables.material_scaling_base + material);
         divisor *= 16384;
-        const optimism_scaled = material_scaled * 64 +
-            optimism * (tunables.optimism_eval_base + tunables.optimism_eval_material_mult * material);
-        divisor *= 64;
-        const fifty_move_rule_scaled = optimism_scaled * (200 - board.halfmove);
+        const fifty_move_rule_scaled = material_scaled * (200 - board.halfmove);
         divisor *= 200;
 
         return @intCast(@divTrunc(fifty_move_rule_scaled, divisor));

--- a/src/main.zig
+++ b/src/main.zig
@@ -659,7 +659,7 @@ pub fn main() !void {
             std.debug.print("average: {d:.4} average abs: {d:.4}\n", .{ average, abs_average });
         } else if (root.evaluation.eval_mode == .nnue and std.ascii.eqlIgnoreCase(command, "nneval")) {
             const raw_eval = root.nnue.evalPosition(&board);
-            const scaled = root.history.HistoryTable.scaleEval(&board, raw_eval, 0);
+            const scaled = root.history.HistoryTable.scaleEval(&board, raw_eval);
             const normalized = root.wdl.normalize(scaled, board.classicalMaterial());
             write("raw eval: {}\n", .{raw_eval});
             write("scaled eval: {}\n", .{scaled});


### PR DESCRIPTION
```
Elo   | 1.89 +- 1.52 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 58714 W: 15175 L: 14856 D: 28683
Penta | [336, 7054, 14293, 7303, 371]
```
https://furybench.com/test/5350/

```
Elo   | 2.20 +- 1.68 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 3.00]
Games | N: 41812 W: 10543 L: 10278 D: 20991
Penta | [82, 4827, 10835, 5068, 94]
```
https://furybench.com/test/5358/

Update corrhist when bestmove is a losing capture. Idea by @cosmobobak

bench: 5671440