### PR TITLE
Remove tthit from rfp cutnode condition 

### DIFF
--- a/src/DebugStats.zig
+++ b/src/DebugStats.zig
@@ -27,6 +27,7 @@ pub const PERCENTILES = [_]f64{
 };
 
 sum: i64 = 0,
+sum_abs: u64 = 0,
 sum_sqr: u128 = 0,
 count: i64 = 0,
 min: i64 = std.math.maxInt(i64),
@@ -42,6 +43,7 @@ pub fn reset(self: *Self) void {
 
 pub fn add(self: *Self, data_point: i64, rng: std.Random) void {
     self.sum += data_point;
+    self.sum_abs += @abs(data_point);
     self.sum_sqr += @as(u128, @abs(data_point)) * @abs(data_point);
     self.count += 1;
     self.min = @min(self.min, data_point);
@@ -81,6 +83,10 @@ pub fn skewness(self: *const Self) f64 {
 
 pub fn average(self: *const Self) f64 {
     return @as(f64, @floatFromInt(self.sum)) / @as(f64, @floatFromInt(self.count));
+}
+
+pub fn averageAbs(self: *const Self) f64 {
+    return @as(f64, @floatFromInt(self.sum_abs)) / @as(f64, @floatFromInt(self.count));
 }
 
 pub fn variance(self: *const Self) f64 {

--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -865,17 +865,13 @@ fn search(
         // reverse futility pruning (rfp)
         if (eval >= beta - tunables.rfp_min_margin) {
             const corrplexity = self.histories.squaredCorrectionTerms(board, cur.move, cur.prev);
-            // cutnodes are expected to fail high
-            // if we are re-searching this then its likely because its important, so otherwise we reduce more
-            // basically we reduce more if this node is likely unimportant
-            const no_tthit_cutnode = !tt_hit and cutnode;
             const opponent_has_easy_capture = board.occupancyFor(stm) & (&board.lesser_threats)[stm.flipped().toInt()] != 0;
             const conditional_margin =
                 tunables.rfp_improving_margin * @intFromBool(improving) +
                 tunables.rfp_easy_margin * @intFromBool(opponent_has_easy_capture) +
                 tunables.rfp_improving_easy_margin * @intFromBool(improving and opponent_has_easy_capture) +
                 tunables.rfp_worsening_margin * @intFromBool(opponent_worsening) +
-                tunables.rfp_cutnode_margin * @intFromBool(no_tthit_cutnode);
+                tunables.rfp_cutnode_margin * @intFromBool(cutnode);
             const history_mult = if (cur.move_is_noisy) tunables.rfp_noisy_history_mult else tunables.rfp_history_mult;
             const rfp_margin =
                 @divTrunc(

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -60,6 +60,7 @@ pub fn printDebugStats() void {
         std.debug.print(
             \\{s}
             \\  avg:  {d:.4}
+            \\  avg abs:  {d:.4}
             \\  std:  {d:.4}
             \\  min:  {d:.4}
             \\  max:  {d:.4}
@@ -70,6 +71,7 @@ pub fn printDebugStats() void {
         , .{
             entry.key_ptr.*,
             entry.value_ptr.average(),
+            entry.value_ptr.averageAbs(),
             entry.value_ptr.standardDeviation(),
             entry.value_ptr.min,
             entry.value_ptr.max,


### PR DESCRIPTION
```
Elo   | -0.45 +- 0.79 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.02 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 192824 W: 46614 L: 46861 D: 99349
Penta | [579, 23129, 49162, 23044, 498]
```
https://furybench.com/test/5379/

```
Elo   | 2.28 +- 3.28 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 1.55 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 10062 W: 2398 L: 2332 D: 5332
Penta | [6, 1121, 2710, 1189, 5]
```
https://furybench.com/test/5385/

bench: 5497095