### PR TITLE
train on data rescored with a much bigger net

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -84,7 +84,7 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
     const name = b.option([]const u8, "name", "change the binary name") orelse "pawnocchio";
     const eval_mode = b.option(Eval, "eval", "which evaluator to use") orelse .nnue;
-    const default_net_path = "pawnocchio-nets/networks/mixed_data_sparse.nnue";
+    const default_net_path = "pawnocchio-nets/networks/mixed_data_chonked3.nnue";
 
     const net_override = b.option(std.Build.LazyPath, "net", "use this net");
     if (eval_mode == .hce and net_override != null) {


### PR DESCRIPTION
```
Elo   | 0.45 +- 3.35 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | -0.18 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11454 W: 2818 L: 2803 D: 5833
Penta | [40, 1404, 2840, 1387, 56]
```
https://furybench.com/test/5391/
```
Elo   | 1.64 +- 1.32 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 64212 W: 15566 L: 15263 D: 33383
Penta | [66, 7366, 16944, 7659, 71]
```
https://furybench.com/test/5395/

```
Elo   | 5.73 +- 3.16 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12424 W: 3209 L: 3004 D: 6211
Penta | [42, 1377, 3188, 1544, 61]
```
https://furybench.com/test/5425/
```
Elo   | 4.69 +- 2.79 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 14600 W: 3567 L: 3370 D: 7663
Penta | [20, 1609, 3846, 1804, 21]
```
https://furybench.com/test/5430/

bench: 5837791