### PR TITLE
Balanced draw randomisation

### DIFF
--- a/src/Board.zig
+++ b/src/Board.zig
@@ -18,6 +18,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 
 const root = @import("root.zig");
+
 const BoundedArray = root.BoundedArray;
 const Colour = root.Colour;
 const File = root.File;

--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -282,8 +282,8 @@ fn evalStateRoot(self: *Searcher) [*]evaluation.State {
 
 fn drawScore(self: *const Searcher, comptime stm: Colour) i16 {
     _ = stm;
-    const r: i16 = @intCast(self.nodes & 7);
-    return r - 3;
+    const r: i16 = @intCast(self.nodes & 2);
+    return r - 1;
 }
 
 fn applyContempt(self: *const Searcher, raw_static_eval: i16) i16 {


### PR DESCRIPTION
```
Elo   | 0.95 +- 1.85 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 34700 W: 8378 L: 8283 D: 18039
Penta | [84, 4066, 8964, 4143, 93]
```
https://furybench.com/test/5483/
bench: 5166076
