### PR TITLE
Fail firm based on depth in main search

### DIFF
--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -1388,6 +1388,11 @@ fn search(
         return if (is_in_check) mated_score else 0;
     }
 
+    if (!is_root and best_score >= beta and !evaluation.isTBScore(best_score) and !evaluation.isTBScore(alpha)) {
+        const w: i32 = @max(0, depth);
+        best_score = @intCast(@divFloor(best_score * w + beta, w + 1));
+    }
+
     if (!is_singular_search) {
         if (score_type == .upper and has_tt_move) {
             best_move = tt_entry.move;


### PR DESCRIPTION
```
Elo   | 5.29 +- 3.00 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 3.00]
Games | N: 13736 W: 3434 L: 3225 D: 7077
Penta | [27, 1596, 3435, 1761, 49]
```
https://furybench.com/test/5531/

TODO: nonreg after tune

bench: 4642020