### PR TITLE
Allow lmr to apply shallower

### DIFF
--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -1227,7 +1227,7 @@ fn search(
 
             var s: i16 = 0;
             var new_depth = depth + extension - 1;
-            if (depth >= 3 and num_searched > 1) {
+            if (depth >= 2 and num_searched > 1) {
                 const history_lmr_mult: i64 = if (is_quiet) tunables.lmr_quiet_history_mult else tunables.lmr_noisy_history_mult;
                 var reduction = calculateBaseLMR(depth, num_searched, is_quiet);
                 reduction -= @intCast(history_lmr_mult * lmr_hist_score >> 13);
@@ -1253,7 +1253,7 @@ fn search(
                 }
 
                 const raw_reduced_depth = depth + extension - (reduction >> 10);
-                const reduced_depth = std.math.clamp(raw_reduced_depth, 1, new_depth) + @intFromBool(is_pv);
+                const reduced_depth = std.math.clamp(raw_reduced_depth, @as(i32, if (depth == 2) 0 else 1), new_depth) + @intFromBool(is_pv);
                 self.stackEntry(0).reduction =
                     if (raw_reduced_depth == reduced_depth)
                         reduction

--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -1253,7 +1253,7 @@ fn search(
                 }
 
                 const raw_reduced_depth = depth + extension - (reduction >> 10);
-                const reduced_depth = std.math.clamp(raw_reduced_depth, @as(i32, if (depth == 2) 0 else 1), new_depth) + @intFromBool(is_pv);
+                const reduced_depth = std.math.clamp(raw_reduced_depth, 1, new_depth) + @intFromBool(is_pv);
                 self.stackEntry(0).reduction =
                     if (raw_reduced_depth == reduced_depth)
                         reduction

--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -923,7 +923,8 @@ fn search(
             eval >= beta + tunables.nmp_margin_base - tunables.nmp_margin_mult * depth and
             non_pk != 0 and
             self.ply >= self.min_nmp_ply and
-            !cur.move.move.isNull())
+            !cur.move.move.isNull() and
+            cutnode)
         {
             self.prefetch(board, Move.init());
             var nmp_reduction = tunables.nmp_base + depth * tunables.nmp_mult;


### PR DESCRIPTION
```
Elo   | 2.33 +- 1.77 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 38630 W: 9495 L: 9236 D: 19899
Penta | [110, 4481, 9880, 4728, 116]
```
https://furybench.com/test/5533/

```
Elo   | 3.42 +- 3.26 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 11372 W: 2802 L: 2690 D: 5880
Penta | [28, 1306, 2915, 1400, 37]
```
https://furybench.com/test/5537/

accidentally did 2 patches at once, one part was then simplified away

bench: 4807672