### PR TITLE
Check that qsearch result is actually less than alpha

### DIFF
--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -912,8 +912,9 @@ fn search(
                 alpha,
                 alpha + 1,
             );
-
-            return evaluation.clampScore(razor_score);
+            if (razor_score <= alpha) {
+                return evaluation.clampScore(razor_score);
+            }
         }
 
         const non_pk = board.occupancyFor(stm) & ~(board.pawns() | board.kings());


### PR DESCRIPTION
```
Elo   | 2.94 +- 2.10 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 27572 W: 6724 L: 6491 D: 14357
Penta | [92, 3139, 7074, 3406, 75]
```
https://furybench.com/test/5562/

```
Elo   | 4.88 +- 4.61 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 1.49 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 5194 W: 1266 L: 1193 D: 2735
Penta | [2, 570, 1384, 635, 6]
```
https://furybench.com/test/5563/

bench: 4833167