### PR TITLE
Don't futility prune moves that give check in qsearch

### DIFF
--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -658,6 +658,7 @@ fn qsearch(
                 futility <= alpha and
                 !is_recapture and
                 @abs(alpha) <= 2000 and
+                !board.isDirectCheck(move) and
                 !SEE.scoreMove(board, move, 1, .pruning))
             {
                 if (!evaluation.isTBScore(best_score)) {


### PR DESCRIPTION
```
Elo   | 5.49 +- 3.06 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12724 W: 3163 L: 2962 D: 6599
Penta | [23, 1442, 3237, 1631, 29]
```
https://furybench.com/test/5686/

```
Elo   | 2.76 +- 2.97 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 1.29 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12444 W: 2993 L: 2894 D: 6557
Penta | [8, 1393, 3320, 1494, 7]
```
https://furybench.com/test/5688/

bench: 5158167