### PR TITLE
Simplify the move count condition in qsearch lmp, now just hp

### DIFF
--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -649,9 +649,7 @@ fn qsearch(
         const is_recapture = move.to() == previous_move_destination;
         if (best_score > evaluation.matedIn(MAX_PLY)) {
             const history_score = self.histories.readNoisy(board, typed);
-            if (num_searched >= 2 and
-                history_score < tunables.qs_hp_margin)
-            {
+            if (history_score < tunables.qs_hp_margin) {
                 break;
             }
             if (!is_in_check and


### PR DESCRIPTION
```
Elo   | -0.05 +- 1.19 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 84356 W: 20298 L: 20311 D: 43747
Penta | [205, 9991, 21806, 9964, 212]
```
https://furybench.com/test/5695/