### PR TITLE
Bonus for direct checks in the movepicker

### DIFF
--- a/src/MovePicker.zig
+++ b/src/MovePicker.zig
@@ -178,7 +178,13 @@ inline fn quietValue(
     typed: TypedMove,
 ) i32 {
     const terms = histories.readMoveTerms(board, typed, conthist_tables, true);
-    return tuning.histQ(terms, tuning.quietHistoryWeights("ord"));
+    var res = tuning.histQ(terms, tuning.quietHistoryWeights("ord"));
+
+    if (board.isDirectCheck(typed.move)) {
+        res += 5000;
+    }
+
+    return res;
 }
 
 const call_modifier: std.builtin.CallModifier = if (@import("builtin").mode == .Debug or @import("builtin").cpu.arch.isPowerPC()) .auto else .always_tail;


### PR DESCRIPTION
```
Elo   | 6.44 +- 3.35 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 3.00]
Games | N: 10892 W: 2715 L: 2513 D: 5664
Penta | [22, 1219, 2790, 1365, 50]
```
https://furybench.com/test/5731/

bench: 2898392