### PR TITLE
Wider LMP margin if move gives check

### DIFF
--- a/src/Searcher.zig
+++ b/src/Searcher.zig
@@ -1088,7 +1088,7 @@ fn search(
             var lmr_depth: i32 = (depth << 10) - base_lmr;
 
             if (!is_pv and
-                num_searched >= lmp_margin)
+                num_searched >= lmp_margin + @as(i32, if (board.isDirectCheck(move)) 1 else 0))
             {
                 mp.skip_quiets = true;
                 if (is_quiet) {


### PR DESCRIPTION
```
Elo   | 3.61 +- 2.35 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.03 (-2.25, 2.89) [0.00, 3.00]
Games | N: 21822 W: 5316 L: 5089 D: 11417
Penta | [62, 2479, 5604, 2702, 64]
```
https://furybench.com/test/5746/

```
Elo   | 8.96 +- 3.90 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.02 (-2.25, 2.89) [0.00, 3.00]
Games | N: 7174 W: 1763 L: 1578 D: 3833
Penta | [2, 745, 1907, 932, 1]
```
https://furybench.com/test/5748/

bench: 4903555