### PR TITLE
SIMD slider attacks using Kogge Stone

### DIFF
--- a/src/Bitboard.zig
+++ b/src/Bitboard.zig
@@ -54,6 +54,112 @@ pub inline fn move(bitboard: u64, d_rank: anytype, d_file: anytype) u64 {
     return res;
 }
 
+const A_FILE: u64 = 0x0101010101010101;
+const B_FILE: u64 = A_FILE << 1;
+const G_FILE: u64 = A_FILE << 6;
+const H_FILE: u64 = A_FILE << 7;
+const RANK_1: u64 = 0xff;
+const RANK_2: u64 = RANK_1 << 8;
+const RANK_7: u64 = RANK_1 << 48;
+const RANK_8: u64 = RANK_1 << 56;
+
+pub fn knightMoveBitBoardSetwise(knights: u64) u64 {
+    const SHIFTS: @Vector(8, u6) = .{
+        6,
+        15,
+        17,
+        10,
+        64 - 6,
+        64 - 15,
+        64 - 17,
+        64 - 10,
+    };
+    const MASKS: @Vector(8, u64) = .{
+        A_FILE | B_FILE | RANK_8,
+        A_FILE | RANK_7 | RANK_8,
+        H_FILE | RANK_7 | RANK_8,
+        G_FILE | H_FILE | RANK_8,
+        G_FILE | H_FILE | RANK_1,
+        H_FILE | RANK_1 | RANK_2,
+        A_FILE | RANK_1 | RANK_2,
+        A_FILE | B_FILE | RANK_1,
+    };
+    return @reduce(.Or, rotl(@as(@Vector(8, u64), @splat(knights)) & ~MASKS, SHIFTS));
+}
+
+pub const SetwiseSliderAttacks = struct {
+    orthogonal: u64,
+    diagonal: u64,
+};
+
+fn rotl(x: @Vector(8, u64), shifts: @Vector(8, u6)) @Vector(8, u64) {
+    return (x << shifts) | (x >> (@as(@Vector(8, u6), @splat(0)) -% shifts));
+}
+
+fn sliderRotate(n: anytype) @Vector(8, u6) {
+    return .{
+        64 - 7 * n,
+        64 - 9 * n,
+        7 * n,
+        9 * n,
+        n,
+        64 - 8 * n,
+        64 - n,
+        8 * n,
+    };
+}
+
+pub fn sliderAttackBitBoardsSetwise(orthogonal: u64, diagonal: u64, blockers: u64) SetwiseSliderAttacks {
+    const ONES = std.math.maxInt(u64);
+    const DIAGONAL_LANES: @Vector(8, u64) = .{
+        ONES,
+        ONES,
+        ONES,
+        ONES,
+        0,
+        0,
+        0,
+        0,
+    };
+    const ORTHOGONAL_LANES: @Vector(8, u64) = ~DIAGONAL_LANES;
+
+    var generated: @Vector(8, u64) = .{
+        diagonal,
+        diagonal,
+        diagonal,
+        diagonal,
+        orthogonal,
+        orthogonal,
+        orthogonal,
+        orthogonal,
+    };
+    const EDGE_MASK: @Vector(8, u64) = .{
+        A_FILE | RANK_8,
+        H_FILE | RANK_8,
+        H_FILE | RANK_1,
+        A_FILE | RANK_1,
+        A_FILE,
+        RANK_8,
+        H_FILE,
+        RANK_1,
+    };
+    var masked_blockers = @as(@Vector(8, u64), @splat(blockers)) | EDGE_MASK;
+
+    generated |= ~masked_blockers & rotl(generated, sliderRotate(1));
+    masked_blockers |= rotl(masked_blockers, sliderRotate(1));
+
+    generated |= ~masked_blockers & rotl(generated, sliderRotate(2));
+    masked_blockers |= rotl(masked_blockers, sliderRotate(2));
+
+    generated |= ~masked_blockers & rotl(generated, sliderRotate(4));
+    generated = ~EDGE_MASK & rotl(generated, sliderRotate(1));
+
+    return .{
+        .orthogonal = @reduce(.Or, generated & ORTHOGONAL_LANES),
+        .diagonal = @reduce(.Or, generated & DIAGONAL_LANES),
+    };
+}
+
 pub fn fileBB(file: root.File) u64 {
     const first_file = std.math.maxInt(u64) / std.math.maxInt(u8);
     return first_file << @intCast(file.toInt());

--- a/src/Board.zig
+++ b/src/Board.zig
@@ -900,9 +900,9 @@ pub fn movePieceCastling(self: *Board, comptime col: Colour, king_from: Square, 
 pub inline fn updateThreats(noalias self: *Board, comptime col: Colour) void {
     const occ = self.occupancy() ^ self.kingFor(col.flipped());
     const pawn_threats = Bitboard.pawnAttackBitBoard(self.pawnsFor(col), col);
-    const knight_threats = Bitboard.knightMoveBitBoard(self.knightsFor(col));
-    var bishop_threats: u64 = 0;
-    var rook_threats: u64 = 0;
+    const knight_threats = Bitboard.knightMoveBitBoardSetwise(self.knightsFor(col));
+    const bishop_threats = Bitboard.sliderAttackBitBoardsSetwise(0, self.bishopsFor(col), occ).diagonal;
+    const rook_threats = Bitboard.sliderAttackBitBoardsSetwise(self.rooksFor(col), 0, occ).orthogonal;
     var queen_threats: u64 = 0;
     const king_threats = Bitboard.kingMoves(Square.fromBitboard(self.kingFor(col)));
     var lesser_threatened: u64 = 0;
@@ -910,27 +910,17 @@ pub inline fn updateThreats(noalias self: *Board, comptime col: Colour) void {
     // threatened now has all pieces attacked by pawns
     // so knights and bishops would be worth more
     lesser_threatened |= (self.knights() | self.bishops()) & pawn_threats;
-    var iter = Bitboard.iterator(self.bishopsFor(col));
-    while (iter.next()) |sq| {
-        bishop_threats |= attacks.bishopAttacks(sq, occ);
-    }
 
     // threatened now has all pieces attacked by pawns or by knights or bishops
     // so rooks are worth more than the attacking pieces
     const minor_threats = pawn_threats | knight_threats | bishop_threats;
     lesser_threatened |= self.rooks() & minor_threats;
 
-    iter = Bitboard.iterator(self.rooksFor(col));
-    while (iter.next()) |sq| {
-        rook_threats |= attacks.rookAttacks(sq, occ);
-    }
-
     // threatened now has all pieces attacked by pawns or by knights or bishops or rooks
     // so queens are worth more than the attacking pieces
     const major_threats = minor_threats | rook_threats;
     lesser_threatened |= self.queens() & major_threats;
-
-    iter = Bitboard.iterator(self.queensFor(col));
+    var iter = Bitboard.iterator(self.queensFor(col));
     while (iter.next()) |sq| {
         queen_threats |= attacks.bishopAttacks(sq, occ) | attacks.rookAttacks(sq, occ);
     }


### PR DESCRIPTION
```
Elo   | 2.81 +- 2.63 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 16208 W: 3975 L: 3844 D: 8389
Penta | [34, 1753, 4409, 1864, 44]
```
https://furybench.com/test/5812/

inspired by @87flowers and @Sp00ph

bench: 4903555