### PR TITLE
Bigger Corrhists

### DIFF
--- a/src/history.zig
+++ b/src/history.zig
@@ -94,7 +94,7 @@ pub const TypedMove = struct {
 };
 
 pub const MAX_HISTORY: i16 = 1 << 14;
-const CORRHIST_SIZE = 16384;
+const CORRHIST_SIZE = 32768;
 const MAX_CORRHIST = 256 * 32;
 const SHIFT = @ctz(MAX_HISTORY);
 pub const CONTHIST_OFFSETS = [_]comptime_int{


### PR DESCRIPTION
```
Elo   | 1.22 +- 0.97 (95%)
SPRT  | 10.0+0.10s Threads=4 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 116170 W: 27831 L: 27423 D: 60916
Penta | [81, 13258, 31005, 13654, 87]
```
https://furybench.com/test/5854/

bench: 5192143