### PR TITLE
Preserve more precision in the crelu side of dual act

### DIFF
--- a/src/nnue.zig
+++ b/src/nnue.zig
@@ -910,9 +910,10 @@ pub const State = struct {
                 }
 
                 // NOTE: PLEASE BE CAREFUL WITH THE QUANTISATION OF THESE BIASES
-                const shifted = intermediate + biases >> @splat(SHIFT);
+                const biased = intermediate + biases;
+                const shifted = biased >> @splat(SHIFT);
 
-                const crelu = std.math.clamp(shifted, LO, HI) << @splat(Q_BITS);
+                const crelu = std.math.clamp(biased, LO, HI << @splat(SHIFT)) >> @splat(SHIFT - Q_BITS);
                 const csrelu = std.math.clamp(shifted * shifted, LO, HI2);
 
                 l1_out_vec[i] = crelu;


### PR DESCRIPTION
```
Elo   | 1.17 +- 0.90 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 145072 W: 34401 L: 33914 D: 76757
Penta | [284, 17117, 37287, 17524, 324]
```
https://furybench.com/test/6244/

ty @tgirolami09 very cool
bench: 3790998