### PR TITLE
Update zig version in build_from_scratch.sh

### DIFF
--- a/build_from_scratch.sh
+++ b/build_from_scratch.sh
@@ -1,8 +1,8 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 curl https://raw.githubusercontent.com/tristanisham/zvm/master/install.sh | bash
 
-VERSION=0.15.2
+VERSION=0.16.0
 $HOME/.zvm/self/zvm i $VERSION
 $HOME/.zvm/self/zvm use $VERSION
 


### PR DESCRIPTION
Also uses /usr/bin/env so bash invocation works across platforms (e.g. on macOS)