### PR TITLE
Preserve more precision in inference

### DIFF
--- a/src/nnue.zig
+++ b/src/nnue.zig
@@ -678,10 +678,10 @@ pub const State = struct {
 
                 const biased = intermediate + biases;
 
-                const crelu: simd.vector(i32) = std.math.clamp(biased, LO, HI) >> @splat(SHIFT - Q_BITS);
+                const crelu = std.math.shr(simd.vector(i32), std.math.clamp(biased, LO, HI), SHIFT - Q_BITS - arch.PRECISION_MARGIN);
 
                 const clamped: simd.vector(i32) = std.math.clamp(biased, -HI, HI);
-                const csrelu: simd.vector(i32) = clamped * clamped >> @splat(SHIFT * 2);
+                const csrelu = std.math.shr(simd.vector(i32), clamped * clamped, SHIFT * 2 - arch.PRECISION_MARGIN);
 
                 l1_out_vec[i] = crelu;
                 l1_out_vec[i + arch.L2_SIZE / simd.vecSize(i32)] = csrelu;
@@ -689,7 +689,7 @@ pub const State = struct {
         }
 
         // in arch.Q³
-        var l2_intermediate: [arch.L3_SIZE / simd.vecSize(i32)]simd.vector(i32) = @bitCast(weights.l2b[output_bucket]);
+        var l2_intermediate: [arch.L3_SIZE / simd.vecSize(i32)]simd.vector(i32) = @splat(@splat(0));
         {
             const l1_out: *const [2 * arch.L2_SIZE]i32 = @ptrCast(&l1_out_vec);
             const l2_weight_vec: *const [2 * arch.L2_SIZE][arch.L3_SIZE / simd.vecSize(i32)]simd.vector(i32) = @ptrCast(@alignCast(&weights.l2w[output_bucket]));
@@ -702,15 +702,22 @@ pub const State = struct {
         }
 
         // in arch.Q⁴
-        var l3_sum: simd.vector(i32) = @splat(0);
+        var l3_sums: [arch.L3_SIZE / simd.vecSize(i32)]simd.vector(i32) = @splat(@splat(0));
         {
-            const l3_weight_vec: *const [arch.L3_SIZE / simd.vecSize(i32)]simd.vector(i32) = @ptrCast(@alignCast(&weights.l3w[output_bucket]));
+            const l2_biases: *const [arch.L3_SIZE / simd.vecSize(i32)]simd.vector(i32) = @ptrCast(&weights.l2b[output_bucket]);
+            const l3_weight_vec: *const [arch.L3_SIZE / simd.vecSize(i32)]simd.vector(i32) = @ptrCast(&weights.l3w[output_bucket]);
             const LO: simd.vector(i32) = @splat(0);
-            const HI3: simd.vector(i32) = @splat(arch.Q * arch.Q * arch.Q);
+            const ONE: simd.vector(i32) = @splat(1);
+            const HI3: simd.vector(i32) = ONE << @splat(arch.L3_SIZE_BITS + 3 * Q_BITS);
             for (0..arch.L3_SIZE / simd.vecSize(i32)) |i| {
-                const activated: simd.vector(i32) = std.math.clamp(l2_intermediate[i], LO, HI3);
-                l3_sum += activated * l3_weight_vec[i];
+                const shifted = std.math.shr(simd.vector(i32), l2_intermediate[i], arch.PRECISION_MARGIN - arch.L3_SIZE_BITS) + l2_biases[i];
+                const activated = std.math.clamp(shifted, LO, HI3);
+                l3_sums[i] += activated * l3_weight_vec[i];
             }
+        }
+        var l3_sum: simd.vector(i32) = @splat(0);
+        for (l3_sums) |e| {
+            l3_sum += std.math.shr(simd.vector(i32), e, arch.L3_SIZE_BITS);
         }
 
         const bias: i32 = weights.l3b[output_bucket];

--- a/src/nnue.zig
+++ b/src/nnue.zig
@@ -144,6 +144,25 @@ pub export fn setWeights(w: *const arch.Weights) void {
     verbatim_weights = w;
 }
 
+pub const PRECISION_MARGIN: comptime_int = blk: {
+    const L1OUT_MAX = arch.Q * arch.Q;
+    const L2W_MAX: comptime_int = inner: {
+        const WEIGHT_COUNT = 2 * arch.L3_SIZE * arch.L2_SIZE;
+
+        const l2w: *const [arch.OUTPUT_BUCKET_COUNT][WEIGHT_COUNT]i32 = @ptrCast(verbatim_backing[@offsetOf(arch.Weights, "l2w")..]);
+
+        var highest: @Vector(WEIGHT_COUNT, u32) = @splat(0);
+        for (l2w) |*w| {
+            highest = @max(highest, @abs(@as(@Vector(WEIGHT_COUNT, i32), w.*)));
+        }
+        break :inner @reduce(.Max, highest);
+    };
+    const MAX_ACC = (2 * arch.L2_SIZE) * L1OUT_MAX * L2W_MAX;
+    const PM: comptime_int = @floor(@log2(@as(comptime_float, std.math.maxInt(i32)) / @as(comptime_float, MAX_ACC)));
+    std.debug.assert((MAX_ACC << PM) <= std.math.maxInt(i32));
+    break :blk PM;
+};
+
 pub fn init() !void {
     if (!use_numa) {
         return;
@@ -678,10 +697,10 @@ pub const State = struct {
 
                 const biased = intermediate + biases;
 
-                const crelu = std.math.shr(simd.vector(i32), std.math.clamp(biased, LO, HI), SHIFT - Q_BITS - arch.PRECISION_MARGIN);
+                const crelu = std.math.shr(simd.vector(i32), std.math.clamp(biased, LO, HI), SHIFT - Q_BITS - PRECISION_MARGIN);
 
                 const clamped: simd.vector(i32) = std.math.clamp(biased, -HI, HI);
-                const csrelu = std.math.shr(simd.vector(i32), clamped * clamped, SHIFT * 2 - arch.PRECISION_MARGIN);
+                const csrelu = std.math.shr(simd.vector(i32), clamped * clamped, SHIFT * 2 - PRECISION_MARGIN);
 
                 l1_out_vec[i] = crelu;
                 l1_out_vec[i + arch.L2_SIZE / simd.vecSize(i32)] = csrelu;
@@ -710,7 +729,7 @@ pub const State = struct {
             const ONE: simd.vector(i32) = @splat(1);
             const HI3: simd.vector(i32) = ONE << @splat(arch.L3_SIZE_BITS + 3 * Q_BITS);
             for (0..arch.L3_SIZE / simd.vecSize(i32)) |i| {
-                const shifted = std.math.shr(simd.vector(i32), l2_intermediate[i], arch.PRECISION_MARGIN - arch.L3_SIZE_BITS) + l2_biases[i];
+                const shifted = std.math.shr(simd.vector(i32), l2_intermediate[i], PRECISION_MARGIN - arch.L3_SIZE_BITS) + l2_biases[i];
                 const activated = std.math.clamp(shifted, LO, HI3);
                 l3_sums[i] += activated * l3_weight_vec[i];
             }

--- a/src/nnue.zig
+++ b/src/nnue.zig
@@ -664,8 +664,8 @@ pub const State = struct {
 
             const SHIFT = Q0_BITS * 2 + MULHI_SHIFT + Q1_BITS - Q_BITS;
             const LO: simd.vector(i32) = @splat(0);
-            const HI: simd.vector(i32) = @splat(arch.Q);
-            const HI2: simd.vector(i32) = @splat(arch.Q * arch.Q);
+            const ONE: simd.vector(i32) = @splat(1);
+            const HI: simd.vector(i32) = ONE << @splat(SHIFT + Q_BITS);
             for (0..arch.L2_SIZE / simd.vecSize(i32)) |i| {
                 const biases: simd.vector(i32) = l1_bias_vec[i];
 
@@ -675,11 +675,13 @@ pub const State = struct {
                 }
 
                 // NOTE: PLEASE BE CAREFUL WITH THE QUANTISATION OF THESE BIASES
-                const biased = intermediate + biases;
-                const shifted = biased >> @splat(SHIFT);
 
-                const crelu: simd.vector(i32) = std.math.clamp(biased, LO, HI << @splat(SHIFT)) >> @splat(SHIFT - Q_BITS);
-                const csrelu: simd.vector(i32) = std.math.clamp(shifted * shifted, LO, HI2);
+                const biased = intermediate + biases;
+
+                const crelu: simd.vector(i32) = std.math.clamp(biased, LO, HI) >> @splat(SHIFT - Q_BITS);
+
+                const clamped: simd.vector(i32) = std.math.clamp(biased, -HI, HI);
+                const csrelu: simd.vector(i32) = clamped * clamped >> @splat(SHIFT * 2);
 
                 l1_out_vec[i] = crelu;
                 l1_out_vec[i + arch.L2_SIZE / simd.vecSize(i32)] = csrelu;

--- a/src/nnue.zig
+++ b/src/nnue.zig
@@ -721,22 +721,18 @@ pub const State = struct {
         }
 
         // in arch.Q⁴
-        var l3_sums: [arch.L3_SIZE / simd.vecSize(i32)]simd.vector(i32) = @splat(@splat(0));
+        var l3_sum: simd.vector(i32) = @splat(0);
         {
             const l2_biases: *const [arch.L3_SIZE / simd.vecSize(i32)]simd.vector(i32) = @ptrCast(&weights.l2b[output_bucket]);
             const l3_weight_vec: *const [arch.L3_SIZE / simd.vecSize(i32)]simd.vector(i32) = @ptrCast(&weights.l3w[output_bucket]);
             const LO: simd.vector(i32) = @splat(0);
             const ONE: simd.vector(i32) = @splat(1);
-            const HI3: simd.vector(i32) = ONE << @splat(arch.L3_SIZE_BITS + 3 * Q_BITS);
+            const HI3: simd.vector(i32) = ONE << @splat(3 * Q_BITS);
             for (0..arch.L3_SIZE / simd.vecSize(i32)) |i| {
-                const shifted = std.math.shr(simd.vector(i32), l2_intermediate[i], PRECISION_MARGIN - arch.L3_SIZE_BITS) + l2_biases[i];
+                const shifted = std.math.shr(simd.vector(i32), l2_intermediate[i], PRECISION_MARGIN) + l2_biases[i];
                 const activated = std.math.clamp(shifted, LO, HI3);
-                l3_sums[i] += activated * l3_weight_vec[i];
+                l3_sum += activated * l3_weight_vec[i];
             }
-        }
-        var l3_sum: simd.vector(i32) = @splat(0);
-        for (l3_sums) |e| {
-            l3_sum += std.math.shr(simd.vector(i32), e, arch.L3_SIZE_BITS);
         }
 
         const bias: i32 = weights.l3b[output_bucket];

--- a/src/nnue.zig
+++ b/src/nnue.zig
@@ -146,18 +146,9 @@ pub export fn setWeights(w: *const arch.Weights) void {
 
 pub const PRECISION_MARGIN: comptime_int = blk: {
     const L1OUT_MAX = arch.Q * arch.Q;
-    const L2W_MAX: comptime_int = inner: {
-        const WEIGHT_COUNT = 2 * arch.L3_SIZE * arch.L2_SIZE;
-
-        const l2w: *const [arch.OUTPUT_BUCKET_COUNT][WEIGHT_COUNT]i32 = @ptrCast(verbatim_backing[@offsetOf(arch.Weights, "l2w")..]);
-
-        var highest: @Vector(WEIGHT_COUNT, u32) = @splat(0);
-        for (l2w) |*w| {
-            highest = @max(highest, @abs(@as(@Vector(WEIGHT_COUNT, i32), w.*)));
-        }
-        break :inner @reduce(.Max, highest);
-    };
-    const MAX_ACC = (2 * arch.L2_SIZE) * L1OUT_MAX * L2W_MAX;
+    const WEIGHT_MAX = 1.98;
+    const L2W_MAX: comptime_int = @round(arch.Q * WEIGHT_MAX);
+    const MAX_ACC: comptime_int = (2 * arch.L2_SIZE) * L1OUT_MAX * L2W_MAX;
     const PM: comptime_int = @floor(@log2(@as(comptime_float, std.math.maxInt(i32)) / @as(comptime_float, MAX_ACC)));
     std.debug.assert((MAX_ACC << PM) <= std.math.maxInt(i32));
     break :blk PM;

--- a/src/nnue_arch.zig
+++ b/src/nnue_arch.zig
@@ -279,13 +279,6 @@ pub const Q = 64;
 
 pub const L3_SIZE_BITS: usize = std.math.log2_int(u32, L3_SIZE);
 
-pub const PRECISION_MARGIN: comptime_int = blk: {
-    const ACC_BITS: comptime_int = std.math.log2_int(u32, std.math.maxInt(i32));
-    const Q_BITS: comptime_int = std.math.log2_int(u32, Q);
-    //         budget     l1out        l2w range      num added terms
-    break :blk ACC_BITS - 2 * Q_BITS - (Q_BITS + 1) - std.math.log2_int(u32, 2 * L2_SIZE);
-};
-
 pub const INPUT_BUCKET_LAYOUT: [64]u8 = .{
     0,  1,  2,  3,  3,  2,  1,  0,
     4,  5,  6,  7,  7,  6,  5,  4,

--- a/src/nnue_arch.zig
+++ b/src/nnue_arch.zig
@@ -239,12 +239,6 @@ pub fn transformNetFor(target_kind: Target, endian: std.builtin.Endian, net: *We
         }
     }
 
-    for (0..OUTPUT_BUCKET_COUNT) |ob| {
-        for (0..L3_SIZE) |i| {
-            net.l2b[ob][i] <<= L3_SIZE_BITS;
-        }
-    }
-
     // transpose l3w
     {
         // [L3_SIZE][OUTPUT_BUCKET_COUNT]i32
@@ -276,8 +270,6 @@ pub const SCALE: i64 = 400;
 pub const Q0 = 255;
 pub const Q1 = 128;
 pub const Q = 64;
-
-pub const L3_SIZE_BITS: usize = std.math.log2_int(u32, L3_SIZE);
 
 pub const INPUT_BUCKET_LAYOUT: [64]u8 = .{
     0,  1,  2,  3,  3,  2,  1,  0,

--- a/src/nnue_arch.zig
+++ b/src/nnue_arch.zig
@@ -28,27 +28,27 @@ pub const Weights = extern struct {
     l3w: [OUTPUT_BUCKET_COUNT][L3_SIZE]i32 align(ALIGNMENT),
     l3b: [OUTPUT_BUCKET_COUNT]i32 align(ALIGNMENT),
 
-    fn l1wInference(self: *Weights) *align(64) [OUTPUT_BUCKET_COUNT][L2_SIZE * L1_SIZE]i8 {
+    fn l1wInferenceLayout(self: *Weights) *align(ALIGNMENT) [OUTPUT_BUCKET_COUNT][L2_SIZE * L1_SIZE]i8 {
         return @ptrCast(&self.l1w);
     }
 
-    fn l1wDisk(self: *Weights) *align(64) [L1_SIZE][OUTPUT_BUCKET_COUNT][L2_SIZE]i8 {
+    fn l1wDiskLayout(self: *Weights) *align(ALIGNMENT) [L1_SIZE][OUTPUT_BUCKET_COUNT][L2_SIZE]i8 {
         return @ptrCast(&self.l1w);
     }
 
-    fn l2wInference(self: *Weights) *align(64) [OUTPUT_BUCKET_COUNT][2 * L3_SIZE * L2_SIZE]i32 {
+    fn l2wInferenceLayout(self: *Weights) *align(ALIGNMENT) [OUTPUT_BUCKET_COUNT][2 * L3_SIZE * L2_SIZE]i32 {
         return @ptrCast(&self.l2w);
     }
 
-    fn l2wDisk(self: *Weights) *align(64) [2 * L2_SIZE][OUTPUT_BUCKET_COUNT][L3_SIZE]i32 {
+    fn l2wDiskLayout(self: *Weights) *align(ALIGNMENT) [2 * L2_SIZE][OUTPUT_BUCKET_COUNT][L3_SIZE]i32 {
         return @ptrCast(&self.l2w);
     }
 
-    fn l3wInference(self: *Weights) *align(64) [OUTPUT_BUCKET_COUNT][L3_SIZE]i32 {
+    fn l3wInferenceLayout(self: *Weights) *align(ALIGNMENT) [OUTPUT_BUCKET_COUNT][L3_SIZE]i32 {
         return @ptrCast(&self.l3w);
     }
 
-    fn l3wDisk(self: *Weights) *align(64) [L3_SIZE][OUTPUT_BUCKET_COUNT]i32 {
+    fn l3wDiskLayout(self: *Weights) *align(ALIGNMENT) [L3_SIZE][OUTPUT_BUCKET_COUNT]i32 {
         return @ptrCast(&self.l3w);
     }
 
@@ -206,10 +206,10 @@ pub fn transformNetFor(target_kind: Target, endian: std.builtin.Endian, net: *We
     // permute l1w for dpbusd
     {
         // [L1_SIZE][OUTPUT_BUCKET_COUNT][L2_SIZE]i8
-        const l1w_disk = net.l1wDisk().*;
+        const l1w_disk = net.l1wDiskLayout().*;
 
         // [OUTPUT_BUCKET_COUNT][L2_SIZE * L1_SIZE]i8
-        const l1w_inf = net.l1wInference();
+        const l1w_inf = net.l1wInferenceLayout();
 
         for (0..OUTPUT_BUCKET_COUNT) |ob| {
             for (0..L1_SIZE / 4) |i| {
@@ -225,10 +225,10 @@ pub fn transformNetFor(target_kind: Target, endian: std.builtin.Endian, net: *We
     // transpose l2w
     {
         // [2 * L2_SIZE][OUTPUT_BUCKET_COUNT][L3_SIZE]i32
-        const l2w_disk = net.l2wDisk().*;
+        const l2w_disk = net.l2wDiskLayout().*;
 
         // [OUTPUT_BUCKET_COUNT][2 * L3_SIZE * L2_SIZE]i32
-        const l2w_inf = net.l2wInference();
+        const l2w_inf = net.l2wInferenceLayout();
 
         for (0..OUTPUT_BUCKET_COUNT) |ob| {
             for (0..2 * L2_SIZE) |i| {
@@ -239,13 +239,19 @@ pub fn transformNetFor(target_kind: Target, endian: std.builtin.Endian, net: *We
         }
     }
 
+    for (0..OUTPUT_BUCKET_COUNT) |ob| {
+        for (0..L3_SIZE) |i| {
+            net.l2b[ob][i] <<= L3_SIZE_BITS;
+        }
+    }
+
     // transpose l3w
     {
         // [L3_SIZE][OUTPUT_BUCKET_COUNT]i32
-        const l3w_disk = net.l3wDisk().*;
+        const l3w_disk = net.l3wDiskLayout().*;
 
         // [OUTPUT_BUCKET_COUNT][L3_SIZE]i32
-        const l3w_inf = net.l3wInference();
+        const l3w_inf = net.l3wInferenceLayout();
 
         for (0..OUTPUT_BUCKET_COUNT) |ob| {
             for (0..L3_SIZE) |i| {
@@ -270,6 +276,16 @@ pub const SCALE: i64 = 400;
 pub const Q0 = 255;
 pub const Q1 = 128;
 pub const Q = 64;
+
+pub const L3_SIZE_BITS: usize = std.math.log2_int(u32, L3_SIZE);
+
+pub const PRECISION_MARGIN: comptime_int = blk: {
+    const ACC_BITS: comptime_int = std.math.log2_int(u32, std.math.maxInt(i32));
+    const Q_BITS: comptime_int = std.math.log2_int(u32, Q);
+    //         budget     l1out        l2w range      num added terms
+    break :blk ACC_BITS - 2 * Q_BITS - (Q_BITS + 1) - std.math.log2_int(u32, 2 * L2_SIZE);
+};
+
 pub const INPUT_BUCKET_LAYOUT: [64]u8 = .{
     0,  1,  2,  3,  3,  2,  1,  0,
     4,  5,  6,  7,  7,  6,  5,  4,


### PR DESCRIPTION
```
Elo   | 0.37 +- 1.57 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 53940 W: 13229 L: 13172 D: 27539
Penta | [321, 6470, 13297, 6595, 287]
```
https://furybench.com/test/6413/

```
Elo   | 1.31 +- 1.98 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.05 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 29996 W: 7118 L: 7005 D: 15873
Penta | [70, 3484, 7769, 3613, 62]
```
https://furybench.com/test/6415/


bench: 4206855